### PR TITLE
P2P credential viewer

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,8 +4,6 @@ PODS:
   - CocoaAsyncSocket (7.6.4)
   - CocoaLibEvent (1.0.0)
   - DoubleConversion (1.1.6)
-  - EthCore (1.0.9):
-    - ISO8601DateFormatter
   - FBLazyVector (0.62.2)
   - FBReactNativeSpec (0.62.2):
     - Folly (= 2018.10.22.00)
@@ -70,7 +68,6 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - ISO8601DateFormatter (0.8)
   - OpenSSL-Universal (1.0.2.19):
     - OpenSSL-Universal/Static (= 1.0.2.19)
   - OpenSSL-Universal/Static (1.0.2.19)
@@ -334,18 +331,11 @@ PODS:
     - Sentry (~> 4.4.0)
   - RNSVG (9.12.0):
     - React
-  - RNUportSigner (1.6.1):
-    - React
-    - UPTEthereumSigner (~> 1.1.5)
   - RNVectorIcons (6.6.0):
     - React
   - Sentry (4.4.3):
     - Sentry/Core (= 4.4.3)
   - Sentry/Core (4.4.3)
-  - UPTEthereumSigner (1.1.5):
-    - EthCore (~> 1.0.9)
-    - Valet (~> 2.4.2)
-  - Valet (2.4.2)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -412,7 +402,6 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNSVG (from `../node_modules/react-native-svg`)
-  - RNUportSigner (from `../node_modules/react-native-uport-signer`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -422,7 +411,6 @@ SPEC REPOS:
     - boost-for-react-native
     - CocoaAsyncSocket
     - CocoaLibEvent
-    - EthCore
     - Flipper
     - Flipper-DoubleConversion
     - Flipper-Folly
@@ -430,11 +418,8 @@ SPEC REPOS:
     - Flipper-PeerTalk
     - Flipper-RSocket
     - FlipperKit
-    - ISO8601DateFormatter
     - OpenSSL-Universal
     - Sentry
-    - UPTEthereumSigner
-    - Valet
     - YogaKit
 
 EXTERNAL SOURCES:
@@ -516,8 +501,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@sentry/react-native"
   RNSVG:
     :path: "../node_modules/react-native-svg"
-  RNUportSigner:
-    :path: "../node_modules/react-native-uport-signer"
   RNVectorIcons:
     :path: "../node_modules/react-native-vector-icons"
   Yoga:
@@ -529,7 +512,6 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  EthCore: f30384fa193fbb5f1ce1cff1fa4a7f5f93408d01
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
   Flipper: 6c1f484f9a88d30ab3e272800d53688439e50f69
@@ -541,7 +523,6 @@ SPEC CHECKSUMS:
   FlipperKit: 6dc9b8f4ef60d9e5ded7f0264db299c91f18832e
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  ISO8601DateFormatter: 4551b6ce4f83185425f583b0b3feb3c7b59b942c
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
@@ -577,11 +558,8 @@ SPEC CHECKSUMS:
   RNScreens: bfa9143ca291bcf3804c932f77b9617ff324704f
   RNSentry: f1c8e34f9109a94b77e946d0ca50803375c1c19e
   RNSVG: 75670614bca635d3dd64bc267bc199e539cb4fa9
-  RNUportSigner: 6f4968dd61b4e856bc6e93fa216b2a7268561923
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
-  UPTEthereumSigner: a14eb8bc74a2094499682f8c374bfd6066ce7440
-  Valet: 14463ef24fab8fd5809044ecedb61484b799fdd6
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "react-native-sqlite-storage": "^5.0.0",
     "react-native-svg": "^9.12.0",
     "react-native-swiper": "^1.5.14",
-    "react-native-uport-signer": "^1.6.1",
     "react-native-vector-icons": "^6.6.0",
     "react-navigation": "^4.3.9",
     "react-navigation-drawer": "^2.4.13",

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -151,7 +151,51 @@ export const NEW_MESSAGE = gql`
     $save: Boolean
   ) {
     handleMessage(raw: $raw, meta: $meta, save: $save) {
-      raw
+      type
+      credentials {
+        id
+        raw
+        credentialSubject
+        expirationDate
+        issuer {
+          did
+          shortId: shortDid
+        }
+        subject {
+          did
+          shortId: shortDid
+        }
+        claims {
+          isObj
+          type
+          value
+        }
+      }
+    }
+  }
+`
+
+export const NEW_CREDENTIAL = gql`
+  mutation handleMessage(
+    $raw: String!
+    $meta: [MetaDataInput]
+    $save: Boolean
+  ) {
+    handleMessage(raw: $raw, meta: $meta, save: $save) {
+      type
+      credentials {
+        id
+        raw
+        issuer {
+          did
+        }
+        subject {
+          did
+        }
+        claims {
+          did
+        }
+      }
     }
   }
 `

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -153,17 +153,15 @@ export const NEW_MESSAGE = gql`
     handleMessage(raw: $raw, meta: $meta, save: $save) {
       type
       credentials {
-        id
+        hash
         raw
         credentialSubject
         expirationDate
         issuer {
           did
-          shortId: shortDid
         }
         subject {
           did
-          shortId: shortDid
         }
         claims {
           isObj

--- a/src/navigators/index.tsx
+++ b/src/navigators/index.tsx
@@ -29,6 +29,7 @@ import MessageProcess from '../screens/main/MessageProcess'
 import Request from '../screens/main/Request'
 import Requests from '../screens/main/Requests/Requests'
 import Credential from '../screens/main/Credential'
+import CredentialView from '../screens/main/CredentialView'
 import CreatingWallet from '../screens/main/CreateIdentity'
 import CreateFirstCredential from '../screens/main/CreateFirstCredential'
 import IssueCredentialScreen from '../screens/main/IssueCredential'
@@ -300,12 +301,10 @@ const App = createStackNavigator(
     Request: Request,
     Requests: Requests,
     Scanner: ScannerNavigator,
-    IssueFirstCredential: {
-      screen: IssueFirstCredential,
-      path: 'issue',
-    },
+    IssueFirstCredential,
     IssueCredential,
     CredentialDetail,
+    CredentialView,
   },
   {
     mode: 'modal',

--- a/src/navigators/screens.ts
+++ b/src/navigators/screens.ts
@@ -20,6 +20,7 @@ const MainScreens = {
     title: 'Create First Credential',
   },
   Credential: { screen: 'Credential', title: 'Credential' },
+  CredentialView: { screen: 'CredentialView', title: 'Credential' },
 }
 
 const UserSettingScreens = {

--- a/src/screens/main/CredentialView.tsx
+++ b/src/screens/main/CredentialView.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import {
+  Container,
+  Screen,
+  Credential,
+  Text,
+  Constants,
+  Button,
+} from '@kancha/kancha-ui'
+import { useNavigation, useNavigationParam } from 'react-navigation-hooks'
+
+type Identity = {
+  did: string
+  shortId: string
+}
+
+interface CredentialViewProps {}
+
+const CredentialView: React.FC<CredentialViewProps> = () => {
+  const navigation = useNavigation()
+
+  const message = useNavigationParam('handleMessage')
+  const credentials = useNavigationParam('credentials')
+  const handleMessage = useNavigationParam('handleMessage')
+
+  const saveMessage = () => {
+    handleMessage({
+      variables: {
+        raw: message,
+        metaData: [{ type: 'reviewed' }],
+        save: true,
+      },
+    })
+
+    navigation.goBack()
+  }
+
+  return (
+    <Screen
+      safeAreaTop
+      footerComponent={
+        <Container flexDirection={'row'} padding paddingBottom={32}>
+          <Container flex={1} marginRight>
+            <Button
+              type={'secondary'}
+              fullWidth
+              buttonText={'Done'}
+              onPress={() => navigation.goBack()}
+              block={'outlined'}
+            />
+          </Container>
+          <Container flex={2}>
+            <Button
+              type={'primary'}
+              disabled={false}
+              fullWidth
+              buttonText={'Save'}
+              onPress={saveMessage}
+              block={'filled'}
+            />
+          </Container>
+        </Container>
+      }
+    >
+      <Container padding>
+        <Container marginBottom={30}>
+          <Text type={Constants.TextTypes.H2} bold>
+            Review Credential
+          </Text>
+        </Container>
+        {credentials.map((vc: any) => {
+          return (
+            <Credential
+              background={'primary'}
+              key={vc.hash}
+              detailMode
+              jwt={vc.raw}
+              issuer={vc.issuer}
+              subject={vc.subject}
+              fields={vc.claims}
+              exp={vc.expirationDate}
+            />
+          )
+        })}
+      </Container>
+    </Screen>
+  )
+}
+
+export default CredentialView

--- a/src/screens/main/CredentialView.tsx
+++ b/src/screens/main/CredentialView.tsx
@@ -19,9 +19,11 @@ interface CredentialViewProps {}
 const CredentialView: React.FC<CredentialViewProps> = () => {
   const navigation = useNavigation()
 
-  const message = useNavigationParam('handleMessage')
+  const message = useNavigationParam('message')
   const credentials = useNavigationParam('credentials')
   const handleMessage = useNavigationParam('handleMessage')
+
+  console.log(message)
 
   const saveMessage = () => {
     handleMessage({
@@ -33,6 +35,18 @@ const CredentialView: React.FC<CredentialViewProps> = () => {
     })
 
     navigation.goBack()
+  }
+
+  const useShortId = (identity: any) => {
+    if (identity.shortId) {
+      return identity
+    }
+    const shortDid = `${identity.did.slice(0, 15)}...${identity.did.slice(-4)}`
+
+    return {
+      ...identity,
+      shortId: shortDid,
+    }
   }
 
   return (
@@ -71,12 +85,12 @@ const CredentialView: React.FC<CredentialViewProps> = () => {
         {credentials.map((vc: any) => {
           return (
             <Credential
-              background={'primary'}
               key={vc.hash}
+              background={'primary'}
               detailMode
               jwt={vc.raw}
-              issuer={vc.issuer}
-              subject={vc.subject}
+              issuer={useShortId(vc.issuer)}
+              subject={useShortId(vc.subject)}
               fields={vc.claims}
               exp={vc.expirationDate}
             />

--- a/src/screens/main/CredentialView.tsx
+++ b/src/screens/main/CredentialView.tsx
@@ -9,11 +9,6 @@ import {
 } from '@kancha/kancha-ui'
 import { useNavigation, useNavigationParam } from 'react-navigation-hooks'
 
-type Identity = {
-  did: string
-  shortId: string
-}
-
 interface CredentialViewProps {}
 
 const CredentialView: React.FC<CredentialViewProps> = () => {
@@ -22,8 +17,6 @@ const CredentialView: React.FC<CredentialViewProps> = () => {
   const message = useNavigationParam('message')
   const credentials = useNavigationParam('credentials')
   const handleMessage = useNavigationParam('handleMessage')
-
-  console.log(message)
 
   const saveMessage = () => {
     handleMessage({

--- a/src/screens/main/IssueCredential.tsx
+++ b/src/screens/main/IssueCredential.tsx
@@ -361,7 +361,7 @@ const IssueCredential: React.FC<NavigationStackScreenProps> & {
 IssueCredential.navigationOptions = ({ navigation }: any) => {
   return {
     title: 'Issue credential',
-    headerLeft: (
+    headerLeft: () => (
       <HeaderButtons>
         <Item title={'Cancel'} onPress={navigation.dismiss} />
       </HeaderButtons>

--- a/src/screens/main/Scanner.tsx
+++ b/src/screens/main/Scanner.tsx
@@ -66,7 +66,6 @@ export default (props: any) => {
         walletConnectOnSessionRequest(e.data)
         props.navigation.dismiss()
       } else {
-        console.log(e.data)
         processDafMessage(e.data)
       }
     }

--- a/src/screens/main/Scanner.tsx
+++ b/src/screens/main/Scanner.tsx
@@ -8,20 +8,56 @@ import { Container, FabButton, Screen } from '@kancha/kancha-ui'
 import { RNCamera } from 'react-native-camera'
 import { Colors, Icons } from '../../theme'
 import { TextInput } from 'react-native-gesture-handler'
+import { NEW_MESSAGE } from '../../lib/graphql/queries'
+import { useMutation } from '@apollo/react-hooks'
 
 export default (props: any) => {
   const [scannerActive, toggleScanner] = useState(true)
   const [inputMode, toggleInputMode] = useState(false)
   const { walletConnectOnSessionRequest } = useContext(WalletConnectContext)
 
+  const [handleMessage] = useMutation(NEW_MESSAGE, {
+    onCompleted(resp) {
+      console.log('Success', resp)
+    },
+    onError(err) {
+      if (err) {
+        console.log('Error', err)
+      }
+    },
+  })
+
   const onPasteJWT = (text: string) => {
     onBarCodeRead({ data: text })
   }
 
-  const processDafMessage = (message: string) => {
-    props.navigation.navigate('MessageProcess', {
-      message,
+  const processDafMessage = async (message: string) => {
+    const decodedMessage = await handleMessage({
+      variables: {
+        raw: message,
+        metaData: [{ type: 'qrCode' }],
+        save: false,
+      },
     })
+    const { type, credentials } = decodedMessage.data.handleMessage
+    switch (type) {
+      case 'w3c.vc':
+        props.navigation.dismiss()
+
+        setTimeout(() => {
+          props.navigation.navigate('CredentialView', {
+            message,
+            credentials,
+            handleMessage,
+          })
+        }, 300)
+
+        return
+      default:
+        props.navigation.navigate('MessageProcess', {
+          message,
+        })
+    }
   }
 
   const onBarCodeRead = (e: any) => {

--- a/src/screens/main/Scanner.tsx
+++ b/src/screens/main/Scanner.tsx
@@ -66,6 +66,7 @@ export default (props: any) => {
         walletConnectOnSessionRequest(e.data)
         props.navigation.dismiss()
       } else {
+        console.log(e.data)
         processDafMessage(e.data)
       }
     }

--- a/src/screens/main/__tests__/CredentialView.test.tsx
+++ b/src/screens/main/__tests__/CredentialView.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import CredentialView from '../CredentialView'
+import { render, fireEvent } from 'react-native-testing-library'
+
+const goBack = jest.fn()
+const handleMessage = jest.fn()
+
+jest.mock('react-navigation-hooks', () => {
+  return {
+    useNavigation: () => {
+      return {
+        goBack: goBack,
+      }
+    },
+    useNavigationParam: (type: string) => {
+      switch (type) {
+        case 'message':
+          return 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1OTIyMjA2ODEsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWNjZXNzIjoiQWxsIEFyZWFzIn19LCJzdWIiOiJkaWQ6ZXRocjpyaW5rZWJ5OjB4NDJjNmU5ODUzYWNjZjRhMzM3NGQxZjU4OTJmNDVlM2FjNmY4ZDk1MyIsImlzcyI6ImRpZDpldGhyOnJpbmtlYnk6MHg0MmM2ZTk4NTNhY2NmNGEzMzc0ZDFmNTg5MmY0NWUzYWM2ZjhkOTUzIn0.EGzRu5jgekeU0oxFPBBLT6QaCHKMT_DasSCh-duy-3crgiuMIRiKbSHmAZCEzB2NYrTiFOx4GSHHKXWWUk5CbgA'
+        case 'credentials':
+          return [
+            {
+              hash:
+                'de9854440c3dcdc212ca62f318230970c6ba343cd89723b1811617fa2a8558e21b182ce1e9a82bac4ea567f1fe0ac50e7b0bdee4b904f8acc370b847858a82f4',
+              raw:
+                'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1OTIyMjA2ODEsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWNjZXNzIjoiQWxsIEFyZWFzIn19LCJzdWIiOiJkaWQ6ZXRocjpyaW5rZWJ5OjB4NDJjNmU5ODUzYWNjZjRhMzM3NGQxZjU4OTJmNDVlM2FjNmY4ZDk1MyIsImlzcyI6ImRpZDpldGhyOnJpbmtlYnk6MHg0MmM2ZTk4NTNhY2NmNGEzMzc0ZDFmNTg5MmY0NWUzYWM2ZjhkOTUzIn0.EGzRu5jgekeU0oxFPBBLT6QaCHKMT_DasSCh-duy-3crgiuMIRiKbSHmAZCEzB2NYrTiFOx4GSHHKXWWUk5CbgA',
+              credentialSubject: {
+                access: 'All Areas',
+              },
+              expirationDate: null,
+              issuer: {
+                did:
+                  'did:ethr:rinkeby:0x42c6e9853accf4a3374d1f5892f45e3ac6f8d953',
+                __typename: 'Identity',
+              },
+              subject: {
+                did:
+                  'did:ethr:rinkeby:0x42c6e9853accf4a3374d1f5892f45e3ac6f8d953',
+                __typename: 'Identity',
+              },
+              claims: [
+                {
+                  isObj: false,
+                  type: 'access',
+                  value: 'All Areas',
+                  __typename: 'Claim',
+                },
+              ],
+              __typename: 'Credential',
+            },
+          ]
+        case 'handleMessage':
+          return handleMessage
+      }
+    },
+  }
+})
+
+describe('Credential View', () => {
+  it('should render with default props', () => {
+    const tree = render(<CredentialView />)
+    expect(tree.toJSON()).toMatchSnapshot()
+  })
+
+  it('should fire cancel event', () => {
+    const { getByText } = render(<CredentialView />)
+    fireEvent.press(getByText('Done'))
+
+    expect(goBack).toHaveBeenCalled()
+  })
+
+  it('should fire save event and handle message', () => {
+    const { getByText } = render(<CredentialView />)
+    fireEvent.press(getByText('Save'))
+
+    expect(handleMessage).toHaveBeenCalled()
+    expect(goBack).toHaveBeenCalled()
+  })
+})

--- a/src/screens/main/__tests__/Request.test.tsx
+++ b/src/screens/main/__tests__/Request.test.tsx
@@ -134,7 +134,10 @@ describe('Request Component', () => {
     const { getByText, getAllByText, unmount } = render(
       // @ts-ignore
       <MockedProvider mocks={mocks} addTypename={false}>
-        <Request navigation={navigation} />
+        {
+          // @ts-ignore
+          <Request navigation={navigation} />
+        }
       </MockedProvider>,
     )
 
@@ -162,13 +165,14 @@ describe('Request Component', () => {
           return 'did:ethr:0x456'
         }
       }),
-      //getParam: jest.fn().mockReturnValue(mockMessage),
     }
 
     const tree = render(
-      // @ts-ignore
       <MockedProvider mocks={[]} addTypename={false}>
-        <Request navigation={navigation} />
+        {
+          // @ts-ignore
+          <Request navigation={navigation} />
+        }
       </MockedProvider>,
     )
     expect(tree.toJSON()).toMatchSnapshot()
@@ -187,13 +191,15 @@ describe('Request Component', () => {
           return 'did:ethr:0x456'
         }
       }),
-      //getParam: jest.fn().mockReturnValue(mockMessage),
     }
 
     const tree = render(
       // @ts-ignore
       <MockedProvider mocks={[]} addTypename={false}>
-        <Request navigation={navigation} />
+        {
+          // @ts-ignore
+          <Request navigation={navigation} />
+        }
       </MockedProvider>,
     )
     expect(tree.toJSON()).toMatchSnapshot()

--- a/src/screens/main/__tests__/Scanner.test.tsx
+++ b/src/screens/main/__tests__/Scanner.test.tsx
@@ -2,6 +2,7 @@ import 'react-native'
 import React from 'react'
 import Scanner from '../Scanner'
 import { render, fireEvent, act } from 'react-native-testing-library'
+import { MockedProvider } from '@apollo/react-testing'
 
 const navigation = {
   goBack: jest.fn(),
@@ -9,16 +10,27 @@ const navigation = {
   navigate: jest.fn(),
 }
 
+jest.useFakeTimers()
+jest.runAllTimers()
+
 describe('Scanner', () => {
   it('renders correctly', () => {
     //@ts-ignore
-    const tree = render(<Scanner navigation={navigation} />).toJSON()
+    const tree = render(
+      <MockedProvider addTypename={false}>
+        <Scanner navigation={navigation} />
+      </MockedProvider>,
+    ).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
   it('cancel button test', () => {
     //@ts-ignore
-    const { getByTestId } = render(<Scanner navigation={navigation} />)
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false}>
+        <Scanner navigation={navigation} />
+      </MockedProvider>,
+    )
     expect(getByTestId('CANCEL_SCAN_BTN')).toBeDefined()
 
     act(() => {
@@ -28,19 +40,12 @@ describe('Scanner', () => {
     expect(navigation.dismiss).toBeCalled()
   })
 
-  it('scanner handler', () => {
-    const component = render(<Scanner navigation={navigation} />)
-    expect(component.getByTestId('CAMERA')).toBeDefined()
-    act(() => {
-      fireEvent(component.getByTestId('CAMERA'), 'barCodeRead', {
-        data: 'test',
-      })
-    })
-    expect(navigation.navigate).toBeCalled()
-  })
-
   it('jwt paste handler', () => {
-    const component = render(<Scanner navigation={navigation} />)
+    const component = render(
+      <MockedProvider addTypename={false}>
+        <Scanner navigation={navigation} />
+      </MockedProvider>,
+    )
     expect(component.getByTestId('ENABLE_PASTE')).toBeDefined()
     //expect(component.getByTestId('JWT_INPUT')).toThrowError()
     act(() => {

--- a/src/screens/main/__tests__/__snapshots__/CredentialView.test.tsx.snap
+++ b/src/screens/main/__tests__/__snapshots__/CredentialView.test.tsx.snap
@@ -1,0 +1,1309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Credential View should render with default props 1`] = `
+Array [
+  <RCTSafeAreaView
+    emulateUnlessSupported={true}
+    style={
+      Object {
+        "backgroundColor": undefined,
+      }
+    }
+  />,
+  <View
+    pointerEvents="auto"
+    style={
+      Object {
+        "alignItems": undefined,
+        "backgroundColor": undefined,
+        "borderRadius": undefined,
+        "flex": 1,
+        "flexDirection": undefined,
+        "height": undefined,
+        "justifyContent": undefined,
+        "margin": undefined,
+        "marginBottom": undefined,
+        "marginLeft": undefined,
+        "marginRight": undefined,
+        "marginTop": undefined,
+        "padding": undefined,
+        "paddingBottom": undefined,
+        "paddingHorizontal": undefined,
+        "paddingLeft": undefined,
+        "paddingRight": undefined,
+        "paddingTop": undefined,
+        "width": undefined,
+      }
+    }
+  >
+    <View
+      pointerEvents="auto"
+      style={
+        Object {
+          "alignItems": undefined,
+          "backgroundColor": undefined,
+          "borderRadius": undefined,
+          "flex": undefined,
+          "flexDirection": undefined,
+          "height": undefined,
+          "justifyContent": undefined,
+          "margin": undefined,
+          "marginBottom": undefined,
+          "marginLeft": undefined,
+          "marginRight": undefined,
+          "marginTop": undefined,
+          "padding": 15,
+          "paddingBottom": undefined,
+          "paddingHorizontal": undefined,
+          "paddingLeft": undefined,
+          "paddingRight": undefined,
+          "paddingTop": undefined,
+          "width": undefined,
+        }
+      }
+    >
+      <View
+        pointerEvents="auto"
+        style={
+          Object {
+            "alignItems": undefined,
+            "backgroundColor": undefined,
+            "borderRadius": undefined,
+            "flex": undefined,
+            "flexDirection": undefined,
+            "height": undefined,
+            "justifyContent": undefined,
+            "margin": undefined,
+            "marginBottom": 30,
+            "marginLeft": undefined,
+            "marginRight": undefined,
+            "marginTop": undefined,
+            "padding": undefined,
+            "paddingBottom": undefined,
+            "paddingHorizontal": undefined,
+            "paddingLeft": undefined,
+            "paddingRight": undefined,
+            "paddingTop": undefined,
+            "width": undefined,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#333333",
+              "flexWrap": "wrap",
+              "fontSize": 24,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Review Credential
+        </Text>
+      </View>
+      <View
+        accessible={true}
+        focusable={false}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "backgroundColor": "#FFFFFF",
+            "borderRadius": 5,
+            "marginBottom": 15,
+          }
+        }
+      >
+        <View
+          pointerEvents="auto"
+          style={
+            Object {
+              "alignItems": undefined,
+              "backgroundColor": undefined,
+              "borderRadius": undefined,
+              "flex": undefined,
+              "flexDirection": undefined,
+              "height": undefined,
+              "justifyContent": undefined,
+              "margin": undefined,
+              "marginBottom": 15,
+              "marginLeft": undefined,
+              "marginRight": undefined,
+              "marginTop": undefined,
+              "padding": 15,
+              "paddingBottom": undefined,
+              "paddingHorizontal": undefined,
+              "paddingLeft": undefined,
+              "paddingRight": undefined,
+              "paddingTop": undefined,
+              "width": undefined,
+            }
+          }
+        >
+          <View
+            pointerEvents="auto"
+            style={
+              Object {
+                "alignItems": "flex-start",
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "flex": undefined,
+                "flexDirection": "row",
+                "height": undefined,
+                "justifyContent": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginTop": undefined,
+                "padding": undefined,
+                "paddingBottom": undefined,
+                "paddingHorizontal": undefined,
+                "paddingLeft": undefined,
+                "paddingRight": undefined,
+                "paddingTop": undefined,
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="auto"
+              style={
+                Object {
+                  "alignItems": undefined,
+                  "backgroundColor": undefined,
+                  "borderRadius": undefined,
+                  "flex": undefined,
+                  "flexDirection": undefined,
+                  "height": undefined,
+                  "justifyContent": undefined,
+                  "margin": undefined,
+                  "marginBottom": undefined,
+                  "marginLeft": undefined,
+                  "marginRight": undefined,
+                  "marginTop": undefined,
+                  "padding": undefined,
+                  "paddingBottom": undefined,
+                  "paddingHorizontal": undefined,
+                  "paddingLeft": undefined,
+                  "paddingRight": undefined,
+                  "paddingTop": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <Image
+                source={
+                  Object {
+                    "uri": "https://www.gravatar.com/avatar/3025b4de7492efa5f6e781a88f43b563?s=80&d=retro",
+                  }
+                }
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "#0078ff",
+                      "borderColor": "#FFFFFF",
+                      "borderRadius": 20,
+                      "borderWidth": 2,
+                      "height": 40,
+                      "width": 40,
+                    },
+                    Object {
+                      "backgroundColor": "transparent",
+                    },
+                  ]
+                }
+              />
+              <View
+                pointerEvents="auto"
+                style={
+                  Object {
+                    "alignItems": undefined,
+                    "backgroundColor": undefined,
+                    "borderRadius": undefined,
+                    "flex": undefined,
+                    "flexDirection": undefined,
+                    "height": undefined,
+                    "justifyContent": undefined,
+                    "left": 15,
+                    "margin": undefined,
+                    "marginBottom": undefined,
+                    "marginLeft": undefined,
+                    "marginRight": undefined,
+                    "marginTop": undefined,
+                    "padding": undefined,
+                    "paddingBottom": undefined,
+                    "paddingHorizontal": undefined,
+                    "paddingLeft": undefined,
+                    "paddingRight": undefined,
+                    "paddingTop": undefined,
+                    "position": "absolute",
+                    "top": 0,
+                    "width": undefined,
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://www.gravatar.com/avatar/3025b4de7492efa5f6e781a88f43b563?s=80&d=retro",
+                    }
+                  }
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "#0078ff",
+                        "borderColor": "#FFFFFF",
+                        "borderRadius": 20,
+                        "borderWidth": 2,
+                        "height": 40,
+                        "width": 40,
+                      },
+                      Object {
+                        "backgroundColor": "transparent",
+                      },
+                    ]
+                  }
+                />
+              </View>
+            </View>
+            <View
+              pointerEvents="auto"
+              style={
+                Object {
+                  "alignItems": undefined,
+                  "backgroundColor": undefined,
+                  "borderRadius": undefined,
+                  "flex": undefined,
+                  "flexDirection": undefined,
+                  "height": undefined,
+                  "justifyContent": undefined,
+                  "margin": undefined,
+                  "marginBottom": undefined,
+                  "marginLeft": 28,
+                  "marginRight": undefined,
+                  "marginTop": undefined,
+                  "padding": undefined,
+                  "paddingBottom": undefined,
+                  "paddingHorizontal": undefined,
+                  "paddingLeft": undefined,
+                  "paddingRight": undefined,
+                  "paddingTop": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <View
+                pointerEvents="auto"
+                style={
+                  Object {
+                    "alignItems": undefined,
+                    "backgroundColor": undefined,
+                    "borderRadius": undefined,
+                    "flex": undefined,
+                    "flexDirection": undefined,
+                    "height": undefined,
+                    "justifyContent": undefined,
+                    "margin": undefined,
+                    "marginBottom": undefined,
+                    "marginLeft": undefined,
+                    "marginRight": undefined,
+                    "marginTop": undefined,
+                    "padding": undefined,
+                    "paddingBottom": undefined,
+                    "paddingHorizontal": undefined,
+                    "paddingLeft": undefined,
+                    "paddingRight": undefined,
+                    "paddingTop": undefined,
+                    "width": undefined,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "flexWrap": "wrap",
+                      "fontSize": 17,
+                      "fontWeight": "bold",
+                    }
+                  }
+                >
+                  did:ethr:rinkeb...d953
+                </Text>
+                <View
+                  pointerEvents="auto"
+                  style={
+                    Object {
+                      "alignItems": "flex-start",
+                      "backgroundColor": undefined,
+                      "borderRadius": undefined,
+                      "flex": undefined,
+                      "flexDirection": "row",
+                      "height": undefined,
+                      "justifyContent": undefined,
+                      "margin": undefined,
+                      "marginBottom": undefined,
+                      "marginLeft": undefined,
+                      "marginRight": undefined,
+                      "marginTop": 3,
+                      "padding": undefined,
+                      "paddingBottom": undefined,
+                      "paddingHorizontal": undefined,
+                      "paddingLeft": undefined,
+                      "paddingRight": undefined,
+                      "paddingTop": undefined,
+                      "width": undefined,
+                    }
+                  }
+                >
+                  <View
+                    pointerEvents="auto"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "backgroundColor": undefined,
+                        "borderRadius": undefined,
+                        "flex": undefined,
+                        "flexDirection": undefined,
+                        "height": undefined,
+                        "justifyContent": undefined,
+                        "margin": undefined,
+                        "marginBottom": undefined,
+                        "marginLeft": undefined,
+                        "marginRight": 5,
+                        "marginTop": undefined,
+                        "padding": undefined,
+                        "paddingBottom": undefined,
+                        "paddingHorizontal": undefined,
+                        "paddingLeft": undefined,
+                        "paddingRight": undefined,
+                        "paddingTop": undefined,
+                        "width": undefined,
+                      }
+                    }
+                  >
+                    <Text
+                      allowFontScaling={false}
+                      style={
+                        Array [
+                          Object {
+                            "color": "#333333",
+                            "fontSize": 15,
+                          },
+                          undefined,
+                          Object {
+                            "fontFamily": "Ionicons",
+                            "fontStyle": "normal",
+                            "fontWeight": "normal",
+                          },
+                          Object {},
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#333333",
+                        "flexWrap": "wrap",
+                        "fontSize": 15,
+                      }
+                    }
+                  >
+                    did:ethr:rinkeb...d953
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            pointerEvents="auto"
+            style={
+              Object {
+                "alignItems": undefined,
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "flex": undefined,
+                "flexDirection": undefined,
+                "height": undefined,
+                "justifyContent": undefined,
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginTop": 30,
+                "padding": undefined,
+                "paddingBottom": undefined,
+                "paddingHorizontal": undefined,
+                "paddingLeft": undefined,
+                "paddingRight": undefined,
+                "paddingTop": undefined,
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="auto"
+              style={
+                Object {
+                  "alignItems": undefined,
+                  "backgroundColor": undefined,
+                  "borderRadius": undefined,
+                  "flex": undefined,
+                  "flexDirection": undefined,
+                  "height": undefined,
+                  "justifyContent": undefined,
+                  "margin": undefined,
+                  "marginBottom": 5,
+                  "marginLeft": undefined,
+                  "marginRight": undefined,
+                  "marginTop": undefined,
+                  "padding": undefined,
+                  "paddingBottom": undefined,
+                  "paddingHorizontal": undefined,
+                  "paddingLeft": undefined,
+                  "paddingRight": undefined,
+                  "paddingTop": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <View
+                pointerEvents="auto"
+                style={
+                  Object {
+                    "alignItems": undefined,
+                    "backgroundColor": undefined,
+                    "borderRadius": undefined,
+                    "flex": undefined,
+                    "flexDirection": undefined,
+                    "height": undefined,
+                    "justifyContent": undefined,
+                    "margin": undefined,
+                    "marginBottom": undefined,
+                    "marginLeft": undefined,
+                    "marginRight": undefined,
+                    "marginTop": undefined,
+                    "padding": undefined,
+                    "paddingBottom": undefined,
+                    "paddingHorizontal": undefined,
+                    "paddingLeft": undefined,
+                    "paddingRight": undefined,
+                    "paddingTop": undefined,
+                    "width": undefined,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#BBBBBB",
+                      "flexWrap": "wrap",
+                      "fontSize": 12,
+                      "textTransform": "uppercase",
+                    }
+                  }
+                >
+                  Access
+                </Text>
+              </View>
+              <View
+                pointerEvents="auto"
+                style={
+                  Object {
+                    "alignItems": undefined,
+                    "backgroundColor": undefined,
+                    "borderRadius": undefined,
+                    "flex": undefined,
+                    "flexDirection": undefined,
+                    "height": undefined,
+                    "justifyContent": "flex-start",
+                    "margin": undefined,
+                    "marginBottom": undefined,
+                    "marginLeft": undefined,
+                    "marginRight": undefined,
+                    "marginTop": undefined,
+                    "padding": undefined,
+                    "paddingBottom": undefined,
+                    "paddingHorizontal": undefined,
+                    "paddingLeft": undefined,
+                    "paddingRight": undefined,
+                    "paddingTop": undefined,
+                    "width": undefined,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#333333",
+                      "flexWrap": "wrap",
+                      "fontSize": 17,
+                    }
+                  }
+                >
+                  All Areas
+                </Text>
+              </View>
+            </View>
+            <View
+              pointerEvents="auto"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": undefined,
+                  "borderRadius": undefined,
+                  "flex": undefined,
+                  "flexDirection": undefined,
+                  "height": undefined,
+                  "justifyContent": "center",
+                  "margin": undefined,
+                  "marginBottom": undefined,
+                  "marginLeft": undefined,
+                  "marginRight": undefined,
+                  "marginTop": 50,
+                  "padding": undefined,
+                  "paddingBottom": undefined,
+                  "paddingHorizontal": undefined,
+                  "paddingLeft": undefined,
+                  "paddingRight": undefined,
+                  "paddingTop": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <RNSVGSvgView
+                bbHeight={200}
+                bbWidth={200}
+                focusable={false}
+                height={200}
+                id="rn-qr-svg-container"
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    undefined,
+                    Object {
+                      "opacity": 1,
+                    },
+                    Object {
+                      "flex": 0,
+                      "height": 200,
+                      "width": 200,
+                    },
+                  ]
+                }
+                width={200}
+              >
+                <RNSVGGroup
+                  fill={
+                    Array [
+                      0,
+                      4278190080,
+                    ]
+                  }
+                  fillOpacity={1}
+                  fillRule={1}
+                  font={Object {}}
+                  matrix={
+                    Array [
+                      1,
+                      0,
+                      0,
+                      1,
+                      0,
+                      0,
+                    ]
+                  }
+                  opacity={1}
+                  originX={0}
+                  originY={0}
+                  propList={Array []}
+                  rotation={0}
+                  scaleX={1}
+                  scaleY={1}
+                  skewX={0}
+                  skewY={0}
+                  stroke={null}
+                  strokeDasharray={null}
+                  strokeDashoffset={null}
+                  strokeLinecap={0}
+                  strokeLinejoin={0}
+                  strokeMiterlimit={4}
+                  strokeOpacity={1}
+                  strokeWidth={1}
+                  vectorEffect={0}
+                  x={0}
+                  y={0}
+                >
+                  <RNSVGRect
+                    fill={
+                      Array [
+                        0,
+                        4294967295,
+                      ]
+                    }
+                    fillOpacity={1}
+                    fillRule={1}
+                    height={200}
+                    matrix={
+                      Array [
+                        1,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                      ]
+                    }
+                    opacity={1}
+                    originX={0}
+                    originY={0}
+                    propList={
+                      Array [
+                        "fill",
+                      ]
+                    }
+                    rotation={0}
+                    scaleX={1}
+                    scaleY={1}
+                    skewX={0}
+                    skewY={0}
+                    stroke={null}
+                    strokeDasharray={null}
+                    strokeDashoffset={null}
+                    strokeLinecap={0}
+                    strokeLinejoin={0}
+                    strokeMiterlimit={4}
+                    strokeOpacity={1}
+                    strokeWidth={1}
+                    vectorEffect={0}
+                    width={200}
+                    x={0}
+                    y={0}
+                  />
+                  <RNSVGSvgView
+                    align="xMidYMid"
+                    bbHeight={200}
+                    bbWidth={200}
+                    focusable={false}
+                    height={200}
+                    id="qr-container"
+                    meetOrSlice={0}
+                    minX={0}
+                    minY={0}
+                    style={
+                      Array [
+                        Object {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        undefined,
+                        Object {
+                          "opacity": 1,
+                        },
+                        Object {
+                          "flex": 0,
+                          "height": 200,
+                          "width": 200,
+                        },
+                      ]
+                    }
+                    vbHeight={100}
+                    vbWidth={100}
+                    width={200}
+                  >
+                    <RNSVGGroup
+                      fill={
+                        Array [
+                          0,
+                          4278190080,
+                        ]
+                      }
+                      fillOpacity={1}
+                      fillRule={1}
+                      font={Object {}}
+                      matrix={
+                        Array [
+                          1,
+                          0,
+                          0,
+                          1,
+                          0,
+                          0,
+                        ]
+                      }
+                      opacity={1}
+                      originX={0}
+                      originY={0}
+                      propList={Array []}
+                      rotation={0}
+                      scaleX={1}
+                      scaleY={1}
+                      skewX={0}
+                      skewY={0}
+                      stroke={null}
+                      strokeDasharray={null}
+                      strokeDashoffset={null}
+                      strokeLinecap={0}
+                      strokeLinejoin={0}
+                      strokeMiterlimit={4}
+                      strokeOpacity={1}
+                      strokeWidth={1}
+                      vectorEffect={0}
+                      x={0}
+                      y={0}
+                    >
+                      <RNSVGDefs>
+                        <RNSVGClipPath
+                          fill={
+                            Array [
+                              0,
+                              4278190080,
+                            ]
+                          }
+                          fillOpacity={1}
+                          fillRule={1}
+                          matrix={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              1,
+                              0,
+                              0,
+                            ]
+                          }
+                          name="clip-wrapper"
+                          opacity={1}
+                          originX={0}
+                          originY={0}
+                          propList={Array []}
+                          rotation={0}
+                          scaleX={1}
+                          scaleY={1}
+                          skewX={0}
+                          skewY={0}
+                          stroke={null}
+                          strokeDasharray={null}
+                          strokeDashoffset={null}
+                          strokeLinecap={0}
+                          strokeLinejoin={0}
+                          strokeMiterlimit={4}
+                          strokeOpacity={1}
+                          strokeWidth={1}
+                          vectorEffect={0}
+                          x={0}
+                          y={0}
+                        >
+                          <RNSVGRect
+                            fill={
+                              Array [
+                                0,
+                                4278190080,
+                              ]
+                            }
+                            fillOpacity={1}
+                            fillRule={1}
+                            height={12}
+                            matrix={
+                              Array [
+                                1,
+                                0,
+                                0,
+                                1,
+                                0,
+                                0,
+                              ]
+                            }
+                            opacity={1}
+                            originX={0}
+                            originY={0}
+                            propList={Array []}
+                            rotation={0}
+                            rx={0}
+                            ry={0}
+                            scaleX={1}
+                            scaleY={1}
+                            skewX={0}
+                            skewY={0}
+                            stroke={null}
+                            strokeDasharray={null}
+                            strokeDashoffset={null}
+                            strokeLinecap={0}
+                            strokeLinejoin={0}
+                            strokeMiterlimit={4}
+                            strokeOpacity={1}
+                            strokeWidth={1}
+                            vectorEffect={0}
+                            width={12}
+                            x={0}
+                            y={0}
+                          />
+                        </RNSVGClipPath>
+                        <RNSVGClipPath
+                          fill={
+                            Array [
+                              0,
+                              4278190080,
+                            ]
+                          }
+                          fillOpacity={1}
+                          fillRule={1}
+                          matrix={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              1,
+                              0,
+                              0,
+                            ]
+                          }
+                          name="clip-logo"
+                          opacity={1}
+                          originX={0}
+                          originY={0}
+                          propList={Array []}
+                          rotation={0}
+                          scaleX={1}
+                          scaleY={1}
+                          skewX={0}
+                          skewY={0}
+                          stroke={null}
+                          strokeDasharray={null}
+                          strokeDashoffset={null}
+                          strokeLinecap={0}
+                          strokeLinejoin={0}
+                          strokeMiterlimit={4}
+                          strokeOpacity={1}
+                          strokeWidth={1}
+                          vectorEffect={0}
+                          x={0}
+                          y={0}
+                        >
+                          <RNSVGRect
+                            fill={
+                              Array [
+                                0,
+                                4278190080,
+                              ]
+                            }
+                            fillOpacity={1}
+                            fillRule={1}
+                            height={10}
+                            matrix={
+                              Array [
+                                1,
+                                0,
+                                0,
+                                1,
+                                0,
+                                0,
+                              ]
+                            }
+                            opacity={1}
+                            originX={0}
+                            originY={0}
+                            propList={Array []}
+                            rotation={0}
+                            rx={0}
+                            ry={0}
+                            scaleX={1}
+                            scaleY={1}
+                            skewX={0}
+                            skewY={0}
+                            stroke={null}
+                            strokeDasharray={null}
+                            strokeDashoffset={null}
+                            strokeLinecap={0}
+                            strokeLinejoin={0}
+                            strokeMiterlimit={4}
+                            strokeOpacity={1}
+                            strokeWidth={1}
+                            vectorEffect={0}
+                            width={10}
+                            x={0}
+                            y={0}
+                          />
+                        </RNSVGClipPath>
+                        <RNSVGLinearGradient
+                          gradient={
+                            Array [
+                              0,
+                              -65536,
+                              1,
+                              -16711681,
+                            ]
+                          }
+                          gradientTransform={
+                            Array [
+                              1,
+                              0,
+                              0,
+                              1,
+                              0,
+                              0,
+                            ]
+                          }
+                          gradientUnits={0}
+                          name="grad"
+                          x1="0%"
+                          x2="100%"
+                          y1="0%"
+                          y2="100%"
+                        />
+                      </RNSVGDefs>
+                      <RNSVGPath
+                        d="M0 0.5617977528089888 L7.865168539325843 0.5617977528089888 M10.112359550561798 0.5617977528089888 L11.235955056179776 0.5617977528089888 M15.730337078651687 0.5617977528089888 L16.853932584269664 0.5617977528089888 M19.10112359550562 0.5617977528089888 L23.59550561797753 0.5617977528089888 M24.719101123595507 0.5617977528089888 L26.966292134831463 0.5617977528089888 M29.213483146067418 0.5617977528089888 L30.337078651685395 0.5617977528089888 M34.831460674157306 0.5617977528089888 L38.20224719101124 0.5617977528089888 M39.325842696629216 0.5617977528089888 L42.69662921348315 0.5617977528089888 M46.06741573033708 0.5617977528089888 L49.438202247191015 0.5617977528089888 M52.80898876404495 0.5617977528089888 L56.17977528089888 0.5617977528089888 M59.55056179775281 0.5617977528089888 L61.79775280898877 0.5617977528089888 M62.921348314606746 0.5617977528089888 L65.1685393258427 0.5617977528089888 M76.40449438202248 0.5617977528089888 L78.65168539325843 0.5617977528089888 M79.77528089887642 0.5617977528089888 L82.02247191011236 0.5617977528089888 M86.51685393258427 0.5617977528089888 L91.01123595505618 0.5617977528089888 M92.13483146067416 0.5617977528089888 L100 0.5617977528089888 M0 1.6853932584269664 L1.1235955056179776 1.6853932584269664 M6.741573033707866 1.6853932584269664 L7.865168539325843 1.6853932584269664 M12.359550561797754 1.6853932584269664 L13.483146067415731 1.6853932584269664 M14.606741573033709 1.6853932584269664 L15.730337078651687 1.6853932584269664 M16.853932584269664 1.6853932584269664 L20.224719101123597 1.6853932584269664 M25.842696629213485 1.6853932584269664 L29.213483146067418 1.6853932584269664 M32.58426966292135 1.6853932584269664 L35.95505617977528 1.6853932584269664 M40.449438202247194 1.6853932584269664 L41.57303370786517 1.6853932584269664 M46.06741573033708 1.6853932584269664 L47.19101123595506 1.6853932584269664 M48.31460674157304 1.6853932584269664 L49.438202247191015 1.6853932584269664 M50.56179775280899 1.6853932584269664 L52.80898876404495 1.6853932584269664 M55.0561797752809 1.6853932584269664 L56.17977528089888 1.6853932584269664 M57.30337078651686 1.6853932584269664 L61.79775280898877 1.6853932584269664 M65.1685393258427 1.6853932584269664 L66.29213483146069 1.6853932584269664 M67.41573033707866 1.6853932584269664 L69.66292134831461 1.6853932584269664 M73.03370786516854 1.6853932584269664 L74.15730337078652 1.6853932584269664 M75.2808988764045 1.6853932584269664 L76.40449438202248 1.6853932584269664 M77.52808988764045 1.6853932584269664 L85.3932584269663 1.6853932584269664 M88.76404494382024 1.6853932584269664 L89.88764044943821 1.6853932584269664 M92.13483146067416 1.6853932584269664 L93.25842696629215 1.6853932584269664 M98.87640449438203 1.6853932584269664 L100 1.6853932584269664 M0 2.808988764044944 L1.1235955056179776 2.808988764044944 M2.247191011235955 2.808988764044944 L5.617977528089888 2.808988764044944 M6.741573033707866 2.808988764044944 L7.865168539325843 2.808988764044944 M8.98876404494382 2.808988764044944 L11.235955056179776 2.808988764044944 M19.10112359550562 2.808988764044944 L20.224719101123597 2.808988764044944 M23.59550561797753 2.808988764044944 L24.719101123595507 2.808988764044944 M26.966292134831463 2.808988764044944 L28.08988764044944 2.808988764044944 M29.213483146067418 2.808988764044944 L30.337078651685395 2.808988764044944 M32.58426966292135 2.808988764044944 L39.325842696629216 2.808988764044944 M40.449438202247194 2.808988764044944 L41.57303370786517 2.808988764044944 M44.943820224719104 2.808988764044944 L46.06741573033708 2.808988764044944 M49.438202247191015 2.808988764044944 L53.932584269662925 2.808988764044944 M55.0561797752809 2.808988764044944 L56.17977528089888 2.808988764044944 M57.30337078651686 2.808988764044944 L59.55056179775281 2.808988764044944 M60.67415730337079 2.808988764044944 L65.1685393258427 2.808988764044944 M66.29213483146069 2.808988764044944 L67.41573033707866 2.808988764044944 M69.66292134831461 2.808988764044944 L73.03370786516854 2.808988764044944 M74.15730337078652 2.808988764044944 L78.65168539325843 2.808988764044944 M79.77528089887642 2.808988764044944 L80.89887640449439 2.808988764044944 M82.02247191011236 2.808988764044944 L87.64044943820225 2.808988764044944 M92.13483146067416 2.808988764044944 L93.25842696629215 2.808988764044944 M94.38202247191012 2.808988764044944 L97.75280898876406 2.808988764044944 M98.87640449438203 2.808988764044944 L100 2.808988764044944 M0 3.9325842696629216 L1.1235955056179776 3.9325842696629216 M2.247191011235955 3.9325842696629216 L5.617977528089888 3.9325842696629216 M6.741573033707866 3.9325842696629216 L7.865168539325843 3.9325842696629216 M8.98876404494382 3.9325842696629216 L10.112359550561798 3.9325842696629216 M11.235955056179776 3.9325842696629216 L13.483146067415731 3.9325842696629216 M15.730337078651687 3.9325842696629216 L16.853932584269664 3.9325842696629216 M21.348314606741575 3.9325842696629216 L24.719101123595507 3.9325842696629216 M25.842696629213485 3.9325842696629216 L26.966292134831463 3.9325842696629216 M30.337078651685395 3.9325842696629216 L31.460674157303373 3.9325842696629216 M32.58426966292135 3.9325842696629216 L37.07865168539326 3.9325842696629216 M38.20224719101124 3.9325842696629216 L39.325842696629216 3.9325842696629216 M40.449438202247194 3.9325842696629216 L42.69662921348315 3.9325842696629216 M46.06741573033708 3.9325842696629216 L49.438202247191015 3.9325842696629216 M53.932584269662925 3.9325842696629216 L55.0561797752809 3.9325842696629216 M61.79775280898877 3.9325842696629216 L62.921348314606746 3.9325842696629216 M64.04494382022472 3.9325842696629216 L65.1685393258427 3.9325842696629216 M69.66292134831461 3.9325842696629216 L74.15730337078652 3.9325842696629216 M76.40449438202248 3.9325842696629216 L78.65168539325843 3.9325842696629216 M84.26966292134833 3.9325842696629216 L85.3932584269663 3.9325842696629216 M87.64044943820225 3.9325842696629216 L88.76404494382024 3.9325842696629216 M89.88764044943821 3.9325842696629216 L91.01123595505618 3.9325842696629216 M92.13483146067416 3.9325842696629216 L93.25842696629215 3.9325842696629216 M94.38202247191012 3.9325842696629216 L97.75280898876406 3.9325842696629216 M98.87640449438203 3.9325842696629216 L100 3.9325842696629216 M0 5.056179775280899 L1.1235955056179776 5.056179775280899 M2.247191011235955 5.056179775280899 L5.617977528089888 5.056179775280899 M6.741573033707866 5.056179775280899 L7.865168539325843 5.056179775280899 M8.98876404494382 5.056179775280899 L10.112359550561798 5.056179775280899 M11.235955056179776 5.056179775280899 L13.483146067415731 5.056179775280899 M14.606741573033709 5.056179775280899 L16.853932584269664 5.056179775280899 M17.97752808988764 5.056179775280899 L19.10112359550562 5.056179775280899 M20.224719101123597 5.056179775280899 L21.348314606741575 5.056179775280899 M24.719101123595507 5.056179775280899 L25.842696629213485 5.056179775280899 M28.08988764044944 5.056179775280899 L30.337078651685395 5.056179775280899 M31.460674157303373 5.056179775280899 L38.20224719101124 5.056179775280899 M39.325842696629216 5.056179775280899 L41.57303370786517 5.056179775280899 M46.06741573033708 5.056179775280899 L48.31460674157304 5.056179775280899 M49.438202247191015 5.056179775280899 L50.56179775280899 5.056179775280899 M52.80898876404495 5.056179775280899 L56.17977528089888 5.056179775280899 M57.30337078651686 5.056179775280899 L58.426966292134836 5.056179775280899 M60.67415730337079 5.056179775280899 L66.29213483146069 5.056179775280899 M67.41573033707866 5.056179775280899 L68.53932584269663 5.056179775280899 M74.15730337078652 5.056179775280899 L75.2808988764045 5.056179775280899 M77.52808988764045 5.056179775280899 L78.65168539325843 5.056179775280899 M79.77528089887642 5.056179775280899 L80.89887640449439 5.056179775280899 M86.51685393258427 5.056179775280899 L87.64044943820225 5.056179775280899 M88.76404494382024 5.056179775280899 L89.88764044943821 5.056179775280899 M92.13483146067416 5.056179775280899 L93.25842696629215 5.056179775280899 M94.38202247191012 5.056179775280899 L97.75280898876406 5.056179775280899 M98.87640449438203 5.056179775280899 L100 5.056179775280899 M0 6.179775280898877 L1.1235955056179776 6.179775280898877 M6.741573033707866 6.179775280898877 L7.865168539325843 6.179775280898877 M8.98876404494382 6.179775280898877 L11.235955056179776 6.179775280898877 M14.606741573033709 6.179775280898877 L16.853932584269664 6.179775280898877 M17.97752808988764 6.179775280898877 L21.348314606741575 6.179775280898877 M22.471910112359552 6.179775280898877 L25.842696629213485 6.179775280898877 M26.966292134831463 6.179775280898877 L30.337078651685395 6.179775280898877 M31.460674157303373 6.179775280898877 L32.58426966292135 6.179775280898877 M35.95505617977528 6.179775280898877 L38.20224719101124 6.179775280898877 M40.449438202247194 6.179775280898877 L42.69662921348315 6.179775280898877 M47.19101123595506 6.179775280898877 L48.31460674157304 6.179775280898877 M49.438202247191015 6.179775280898877 L51.68539325842697 6.179775280898877 M55.0561797752809 6.179775280898877 L56.17977528089888 6.179775280898877 M57.30337078651686 6.179775280898877 L61.79775280898877 6.179775280898877 M65.1685393258427 6.179775280898877 L66.29213483146069 6.179775280898877 M69.66292134831461 6.179775280898877 L74.15730337078652 6.179775280898877 M78.65168539325843 6.179775280898877 L79.77528089887642 6.179775280898877 M83.14606741573034 6.179775280898877 L84.26966292134833 6.179775280898877 M88.76404494382024 6.179775280898877 L89.88764044943821 6.179775280898877 M92.13483146067416 6.179775280898877 L93.25842696629215 6.179775280898877 M98.87640449438203 6.179775280898877 L100 6.179775280898877 M0 7.3033707865168545 L7.865168539325843 7.3033707865168545 M8.98876404494382 7.3033707865168545 L10.112359550561798 7.3033707865168545 M11.235955056179776 7.3033707865168545 L12.359550561797754 7.3033707865168545 M13.483146067415731 7.3033707865168545 L14.606741573033709 7.3033707865168545 M15.730337078651687 7.3033707865168545 L16.853932584269664 7.3033707865168545 M17.97752808988764 7.3033707865168545 L19.10112359550562 7.3033707865168545 M20.224719101123597 7.3033707865168545 L21.348314606741575 7.3033707865168545 M22.471910112359552 7.3033707865168545 L23.59550561797753 7.3033707865168545 M24.719101123595507 7.3033707865168545 L25.842696629213485 7.3033707865168545 M26.966292134831463 7.3033707865168545 L28.08988764044944 7.3033707865168545 M29.213483146067418 7.3033707865168545 L30.337078651685395 7.3033707865168545 M31.460674157303373 7.3033707865168545 L32.58426966292135 7.3033707865168545 M33.70786516853933 7.3033707865168545 L34.831460674157306 7.3033707865168545 M35.95505617977528 7.3033707865168545 L37.07865168539326 7.3033707865168545 M38.20224719101124 7.3033707865168545 L39.325842696629216 7.3033707865168545 M40.449438202247194 7.3033707865168545 L41.57303370786517 7.3033707865168545 M42.69662921348315 7.3033707865168545 L43.82022471910113 7.3033707865168545 M44.943820224719104 7.3033707865168545 L46.06741573033708 7.3033707865168545 M47.19101123595506 7.3033707865168545 L48.31460674157304 7.3033707865168545 M49.438202247191015 7.3033707865168545 L50.56179775280899 7.3033707865168545 M51.68539325842697 7.3033707865168545 L52.80898876404495 7.3033707865168545 M53.932584269662925 7.3033707865168545 L55.0561797752809 7.3033707865168545 M56.17977528089888 7.3033707865168545 L57.30337078651686 7.3033707865168545 M58.426966292134836 7.3033707865168545 L59.55056179775281 7.3033707865168545 M60.67415730337079 7.3033707865168545 L61.79775280898877 7.3033707865168545 M62.921348314606746 7.3033707865168545 L64.04494382022472 7.3033707865168545 M65.1685393258427 7.3033707865168545 L66.29213483146069 7.3033707865168545 M67.41573033707866 7.3033707865168545 L68.53932584269663 7.3033707865168545 M69.66292134831461 7.3033707865168545 L70.7865168539326 7.3033707865168545 M71.91011235955057 7.3033707865168545 L73.03370786516854 7.3033707865168545 M74.15730337078652 7.3033707865168545 L75.2808988764045 7.3033707865168545 M76.40449438202248 7.3033707865168545 L77.52808988764045 7.3033707865168545 M78.65168539325843 7.3033707865168545 L79.77528089887642 7.3033707865168545 M80.89887640449439 7.3033707865168545 L82.02247191011236 7.3033707865168545 M83.14606741573034 7.3033707865168545 L84.26966292134833 7.3033707865168545 M85.3932584269663 7.3033707865168545 L86.51685393258427 7.3033707865168545 M87.64044943820225 7.3033707865168545 L88.76404494382024 7.3033707865168545 M89.88764044943821 7.3033707865168545 L91.01123595505618 7.3033707865168545 M92.13483146067416 7.3033707865168545 L100 7.3033707865168545 M8.98876404494382 8.426966292134832 L12.359550561797754 8.426966292134832 M15.730337078651687 8.426966292134832 L20.224719101123597 8.426966292134832 M21.348314606741575 8.426966292134832 L22.471910112359552 8.426966292134832 M23.59550561797753 8.426966292134832 L25.842696629213485 8.426966292134832 M28.08988764044944 8.426966292134832 L29.213483146067418 8.426966292134832 M31.460674157303373 8.426966292134832 L32.58426966292135 8.426966292134832 M35.95505617977528 8.426966292134832 L40.449438202247194 8.426966292134832 M42.69662921348315 8.426966292134832 L43.82022471910113 8.426966292134832 M44.943820224719104 8.426966292134832 L46.06741573033708 8.426966292134832 M49.438202247191015 8.426966292134832 L50.56179775280899 8.426966292134832 M53.932584269662925 8.426966292134832 L56.17977528089888 8.426966292134832 M58.426966292134836 8.426966292134832 L59.55056179775281 8.426966292134832 M60.67415730337079 8.426966292134832 L61.79775280898877 8.426966292134832 M65.1685393258427 8.426966292134832 L68.53932584269663 8.426966292134832 M69.66292134831461 8.426966292134832 L70.7865168539326 8.426966292134832 M74.15730337078652 8.426966292134832 L75.2808988764045 8.426966292134832 M76.40449438202248 8.426966292134832 L78.65168539325843 8.426966292134832 M79.77528089887642 8.426966292134832 L82.02247191011236 8.426966292134832 M84.26966292134833 8.426966292134832 L86.51685393258427 8.426966292134832 M0 9.55056179775281 L1.1235955056179776 9.55056179775281 M2.247191011235955 9.55056179775281 L7.865168539325843 9.55056179775281 M12.359550561797754 9.55056179775281 L13.483146067415731 9.55056179775281 M17.97752808988764 9.55056179775281 L19.10112359550562 9.55056179775281 M20.224719101123597 9.55056179775281 L21.348314606741575 9.55056179775281 M22.471910112359552 9.55056179775281 L23.59550561797753 9.55056179775281 M24.719101123595507 9.55056179775281 L28.08988764044944 9.55056179775281 M29.213483146067418 9.55056179775281 L42.69662921348315 9.55056179775281 M48.31460674157304 9.55056179775281 L49.438202247191015 9.55056179775281 M50.56179775280899 9.55056179775281 L53.932584269662925 9.55056179775281 M55.0561797752809 9.55056179775281 L58.426966292134836 9.55056179775281 M59.55056179775281 9.55056179775281 L66.29213483146069 9.55056179775281 M68.53932584269663 9.55056179775281 L69.66292134831461 9.55056179775281 M70.7865168539326 9.55056179775281 L73.03370786516854 9.55056179775281 M74.15730337078652 9.55056179775281 L76.40449438202248 9.55056179775281 M77.52808988764045 9.55056179775281 L78.65168539325843 9.55056179775281 M82.02247191011236 9.55056179775281 L83.14606741573034 9.55056179775281 M84.26966292134833 9.55056179775281 L85.3932584269663 9.55056179775281 M87.64044943820225 9.55056179775281 L88.76404494382024 9.55056179775281 M89.88764044943821 9.55056179775281 L91.01123595505618 9.55056179775281 M92.13483146067416 9.55056179775281 L97.75280898876406 9.55056179775281 M0 10.674157303370787 L1.1235955056179776 10.674157303370787 M8.98876404494382 10.674157303370787 L10.112359550561798 10.674157303370787 M12.359550561797754 10.674157303370787 L13.483146067415731 10.674157303370787 M17.97752808988764 10.674157303370787 L24.719101123595507 10.674157303370787 M25.842696629213485 10.674157303370787 L28.08988764044944 10.674157303370787 M31.460674157303373 10.674157303370787 L32.58426966292135 10.674157303370787 M33.70786516853933 10.674157303370787 L35.95505617977528 10.674157303370787 M38.20224719101124 10.674157303370787 L40.449438202247194 10.674157303370787 M41.57303370786517 10.674157303370787 L42.69662921348315 10.674157303370787 M46.06741573033708 10.674157303370787 L49.438202247191015 10.674157303370787 M55.0561797752809 10.674157303370787 L56.17977528089888 10.674157303370787 M62.921348314606746 10.674157303370787 L66.29213483146069 10.674157303370787 M67.41573033707866 10.674157303370787 L68.53932584269663 10.674157303370787 M70.7865168539326 10.674157303370787 L71.91011235955057 10.674157303370787 M74.15730337078652 10.674157303370787 L79.77528089887642 10.674157303370787 M83.14606741573034 10.674157303370787 L86.51685393258427 10.674157303370787 M88.76404494382024 10.674157303370787 L89.88764044943821 10.674157303370787 M91.01123595505618 10.674157303370787 L93.25842696629215 10.674157303370787 M97.75280898876406 10.674157303370787 L100 10.674157303370787 M1.1235955056179776 11.797752808988765 L2.247191011235955 11.797752808988765 M5.617977528089888 11.797752808988765 L7.865168539325843 11.797752808988765 M8.98876404494382 11.797752808988765 L10.112359550561798 11.797752808988765 M14.606741573033709 11.797752808988765 L15.730337078651687 11.797752808988765 M16.853932584269664 11.797752808988765 L17.97752808988764 11.797752808988765 M19.10112359550562 11.797752808988765 L20.224719101123597 11.797752808988765 M22.471910112359552 11.797752808988765 L25.842696629213485 11.797752808988765 M29.213483146067418 11.797752808988765 L30.337078651685395 11.797752808988765 M35.95505617977528 11.797752808988765 L38.20224719101124 11.797752808988765 M40.449438202247194 11.797752808988765 L41.57303370786517 11.797752808988765 M46.06741573033708 11.797752808988765 L48.31460674157304 11.797752808988765 M49.438202247191015 11.797752808988765 L50.56179775280899 11.797752808988765 M51.68539325842697 11.797752808988765 L53.932584269662925 11.797752808988765 M55.0561797752809 11.797752808988765 L56.17977528089888 11.797752808988765 M57.30337078651686 11.797752808988765 L61.79775280898877 11.797752808988765 M62.921348314606746 11.797752808988765 L65.1685393258427 11.797752808988765 M66.29213483146069 11.797752808988765 L67.41573033707866 11.797752808988765 M68.53932584269663 11.797752808988765 L70.7865168539326 11.797752808988765 M71.91011235955057 11.797752808988765 L74.15730337078652 11.797752808988765 M75.2808988764045 11.797752808988765 L79.77528089887642 11.797752808988765 M80.89887640449439 11.797752808988765 L85.3932584269663 11.797752808988765 M86.51685393258427 11.797752808988765 L87.64044943820225 11.797752808988765 M88.76404494382024 11.797752808988765 L91.01123595505618 11.797752808988765 M93.25842696629215 11.797752808988765 L95.50561797752809 11.797752808988765 M96.62921348314607 11.797752808988765 L97.75280898876406 11.797752808988765 M0 12.921348314606742 L2.247191011235955 12.921348314606742 M3.370786516853933 12.921348314606742 L4.49438202247191 12.921348314606742 M5.617977528089888 12.921348314606742 L6.741573033707866 12.921348314606742 M10.112359550561798 12.921348314606742 L14.606741573033709 12.921348314606742 M15.730337078651687 12.921348314606742 L17.97752808988764 12.921348314606742 M20.224719101123597 12.921348314606742 L21.348314606741575 12.921348314606742 M22.471910112359552 12.921348314606742 L23.59550561797753 12.921348314606742 M24.719101123595507 12.921348314606742 L25.842696629213485 12.921348314606742 M28.08988764044944 12.921348314606742 L29.213483146067418 12.921348314606742 M30.337078651685395 12.921348314606742 L38.20224719101124 12.921348314606742 M43.82022471910113 12.921348314606742 L44.943820224719104 12.921348314606742 M48.31460674157304 12.921348314606742 L49.438202247191015 12.921348314606742 M53.932584269662925 12.921348314606742 L55.0561797752809 12.921348314606742 M57.30337078651686 12.921348314606742 L58.426966292134836 12.921348314606742 M61.79775280898877 12.921348314606742 L66.29213483146069 12.921348314606742 M70.7865168539326 12.921348314606742 L73.03370786516854 12.921348314606742 M75.2808988764045 12.921348314606742 L80.89887640449439 12.921348314606742 M82.02247191011236 12.921348314606742 L83.14606741573034 12.921348314606742 M84.26966292134833 12.921348314606742 L89.88764044943821 12.921348314606742 M93.25842696629215 12.921348314606742 L96.62921348314607 12.921348314606742 M98.87640449438203 12.921348314606742 L100 12.921348314606742 M0 14.04494382022472 L4.49438202247191 14.04494382022472 M5.617977528089888 14.04494382022472 L8.98876404494382 14.04494382022472 M11.235955056179776 14.04494382022472 L15.730337078651687 14.04494382022472 M19.10112359550562 14.04494382022472 L25.842696629213485 14.04494382022472 M28.08988764044944 14.04494382022472 L34.831460674157306 14.04494382022472 M35.95505617977528 14.04494382022472 L37.07865168539326 14.04494382022472 M40.449438202247194 14.04494382022472 L41.57303370786517 14.04494382022472 M46.06741573033708 14.04494382022472 L47.19101123595506 14.04494382022472 M48.31460674157304 14.04494382022472 L49.438202247191015 14.04494382022472 M50.56179775280899 14.04494382022472 L56.17977528089888 14.04494382022472 M59.55056179775281 14.04494382022472 L60.67415730337079 14.04494382022472 M62.921348314606746 14.04494382022472 L64.04494382022472 14.04494382022472 M65.1685393258427 14.04494382022472 L66.29213483146069 14.04494382022472 M67.41573033707866 14.04494382022472 L68.53932584269663 14.04494382022472 M69.66292134831461 14.04494382022472 L71.91011235955057 14.04494382022472 M73.03370786516854 14.04494382022472 L75.2808988764045 14.04494382022472 M76.40449438202248 14.04494382022472 L78.65168539325843 14.04494382022472 M84.26966292134833 14.04494382022472 L85.3932584269663 14.04494382022472 M88.76404494382024 14.04494382022472 L93.25842696629215 14.04494382022472 M96.62921348314607 14.04494382022472 L100 14.04494382022472 M0 15.168539325842698 L2.247191011235955 15.168539325842698 M8.98876404494382 15.168539325842698 L13.483146067415731 15.168539325842698 M15.730337078651687 15.168539325842698 L20.224719101123597 15.168539325842698 M21.348314606741575 15.168539325842698 L23.59550561797753 15.168539325842698 M30.337078651685395 15.168539325842698 L31.460674157303373 15.168539325842698 M32.58426966292135 15.168539325842698 L34.831460674157306 15.168539325842698 M35.95505617977528 15.168539325842698 L39.325842696629216 15.168539325842698 M40.449438202247194 15.168539325842698 L42.69662921348315 15.168539325842698 M43.82022471910113 15.168539325842698 L44.943820224719104 15.168539325842698 M46.06741573033708 15.168539325842698 L50.56179775280899 15.168539325842698 M53.932584269662925 15.168539325842698 L55.0561797752809 15.168539325842698 M57.30337078651686 15.168539325842698 L59.55056179775281 15.168539325842698 M61.79775280898877 15.168539325842698 L66.29213483146069 15.168539325842698 M69.66292134831461 15.168539325842698 L70.7865168539326 15.168539325842698 M71.91011235955057 15.168539325842698 L73.03370786516854 15.168539325842698 M76.40449438202248 15.168539325842698 L79.77528089887642 15.168539325842698 M80.89887640449439 15.168539325842698 L82.02247191011236 15.168539325842698 M93.25842696629215 15.168539325842698 L94.38202247191012 15.168539325842698 M96.62921348314607 15.168539325842698 L100 15.168539325842698 M3.370786516853933 16.292134831460675 L8.98876404494382 16.292134831460675 M11.235955056179776 16.292134831460675 L12.359550561797754 16.292134831460675 M14.606741573033709 16.292134831460675 L15.730337078651687 16.292134831460675 M17.97752808988764 16.292134831460675 L19.10112359550562 16.292134831460675 M20.224719101123597 16.292134831460675 L24.719101123595507 16.292134831460675 M25.842696629213485 16.292134831460675 L28.08988764044944 16.292134831460675 M29.213483146067418 16.292134831460675 L33.70786516853933 16.292134831460675 M34.831460674157306 16.292134831460675 L35.95505617977528 16.292134831460675 M37.07865168539326 16.292134831460675 L39.325842696629216 16.292134831460675 M40.449438202247194 16.292134831460675 L42.69662921348315 16.292134831460675 M47.19101123595506 16.292134831460675 L49.438202247191015 16.292134831460675 M50.56179775280899 16.292134831460675 L51.68539325842697 16.292134831460675 M55.0561797752809 16.292134831460675 L56.17977528089888 16.292134831460675 M57.30337078651686 16.292134831460675 L59.55056179775281 16.292134831460675 M65.1685393258427 16.292134831460675 L67.41573033707866 16.292134831460675 M69.66292134831461 16.292134831460675 L70.7865168539326 16.292134831460675 M71.91011235955057 16.292134831460675 L74.15730337078652 16.292134831460675 M76.40449438202248 16.292134831460675 L78.65168539325843 16.292134831460675 M79.77528089887642 16.292134831460675 L82.02247191011236 16.292134831460675 M83.14606741573034 16.292134831460675 L84.26966292134833 16.292134831460675 M86.51685393258427 16.292134831460675 L87.64044943820225 16.292134831460675 M88.76404494382024 16.292134831460675 L89.88764044943821 16.292134831460675 M95.50561797752809 16.292134831460675 L96.62921348314607 16.292134831460675 M0 17.415730337078653 L1.1235955056179776 17.415730337078653 M5.617977528089888 17.415730337078653 L6.741573033707866 17.415730337078653 M7.865168539325843 17.415730337078653 L8.98876404494382 17.415730337078653 M12.359550561797754 17.415730337078653 L13.483146067415731 17.415730337078653 M14.606741573033709 17.415730337078653 L15.730337078651687 17.415730337078653 M17.97752808988764 17.415730337078653 L19.10112359550562 17.415730337078653 M20.224719101123597 17.415730337078653 L22.471910112359552 17.415730337078653 M23.59550561797753 17.415730337078653 L24.719101123595507 17.415730337078653 M25.842696629213485 17.415730337078653 L26.966292134831463 17.415730337078653 M28.08988764044944 17.415730337078653 L31.460674157303373 17.415730337078653 M33.70786516853933 17.415730337078653 L35.95505617977528 17.415730337078653 M37.07865168539326 17.415730337078653 L39.325842696629216 17.415730337078653 M40.449438202247194 17.415730337078653 L46.06741573033708 17.415730337078653 M48.31460674157304 17.415730337078653 L50.56179775280899 17.415730337078653 M51.68539325842697 17.415730337078653 L53.932584269662925 17.415730337078653 M55.0561797752809 17.415730337078653 L56.17977528089888 17.415730337078653 M57.30337078651686 17.415730337078653 L60.67415730337079 17.415730337078653 M61.79775280898877 17.415730337078653 L65.1685393258427 17.415730337078653 M66.29213483146069 17.415730337078653 L69.66292134831461 17.415730337078653 M76.40449438202248 17.415730337078653 L77.52808988764045 17.415730337078653 M78.65168539325843 17.415730337078653 L80.89887640449439 17.415730337078653 M83.14606741573034 17.415730337078653 L88.76404494382024 17.415730337078653 M93.25842696629215 17.415730337078653 L96.62921348314607 17.415730337078653 M98.87640449438203 17.415730337078653 L100 17.415730337078653 M2.247191011235955 18.53932584269663 L3.370786516853933 18.53932584269663 M4.49438202247191 18.53932584269663 L5.617977528089888 18.53932584269663 M6.741573033707866 18.53932584269663 L8.98876404494382 18.53932584269663 M10.112359550561798 18.53932584269663 L11.235955056179776 18.53932584269663 M13.483146067415731 18.53932584269663 L14.606741573033709 18.53932584269663 M15.730337078651687 18.53932584269663 L17.97752808988764 18.53932584269663 M19.10112359550562 18.53932584269663 L20.224719101123597 18.53932584269663 M26.966292134831463 18.53932584269663 L29.213483146067418 18.53932584269663 M32.58426966292135 18.53932584269663 L33.70786516853933 18.53932584269663 M34.831460674157306 18.53932584269663 L38.20224719101124 18.53932584269663 M39.325842696629216 18.53932584269663 L40.449438202247194 18.53932584269663 M42.69662921348315 18.53932584269663 L43.82022471910113 18.53932584269663 M47.19101123595506 18.53932584269663 L48.31460674157304 18.53932584269663 M50.56179775280899 18.53932584269663 L51.68539325842697 18.53932584269663 M52.80898876404495 18.53932584269663 L55.0561797752809 18.53932584269663 M56.17977528089888 18.53932584269663 L57.30337078651686 18.53932584269663 M60.67415730337079 18.53932584269663 L61.79775280898877 18.53932584269663 M69.66292134831461 18.53932584269663 L71.91011235955057 18.53932584269663 M74.15730337078652 18.53932584269663 L75.2808988764045 18.53932584269663 M84.26966292134833 18.53932584269663 L86.51685393258427 18.53932584269663 M87.64044943820225 18.53932584269663 L92.13483146067416 18.53932584269663 M94.38202247191012 18.53932584269663 L95.50561797752809 18.53932584269663 M98.87640449438203 18.53932584269663 L100 18.53932584269663 M1.1235955056179776 19.662921348314608 L2.247191011235955 19.662921348314608 M3.370786516853933 19.662921348314608 L5.617977528089888 19.662921348314608 M8.98876404494382 19.662921348314608 L10.112359550561798 19.662921348314608 M12.359550561797754 19.662921348314608 L14.606741573033709 19.662921348314608 M16.853932584269664 19.662921348314608 L21.348314606741575 19.662921348314608 M22.471910112359552 19.662921348314608 L32.58426966292135 19.662921348314608 M34.831460674157306 19.662921348314608 L37.07865168539326 19.662921348314608 M38.20224719101124 19.662921348314608 L39.325842696629216 19.662921348314608 M41.57303370786517 19.662921348314608 L42.69662921348315 19.662921348314608 M47.19101123595506 19.662921348314608 L49.438202247191015 19.662921348314608 M52.80898876404495 19.662921348314608 L56.17977528089888 19.662921348314608 M60.67415730337079 19.662921348314608 L61.79775280898877 19.662921348314608 M62.921348314606746 19.662921348314608 L66.29213483146069 19.662921348314608 M70.7865168539326 19.662921348314608 L73.03370786516854 19.662921348314608 M75.2808988764045 19.662921348314608 L79.77528089887642 19.662921348314608 M80.89887640449439 19.662921348314608 L82.02247191011236 19.662921348314608 M84.26966292134833 19.662921348314608 L85.3932584269663 19.662921348314608 M89.88764044943821 19.662921348314608 L91.01123595505618 19.662921348314608 M94.38202247191012 19.662921348314608 L95.50561797752809 19.662921348314608 M96.62921348314607 19.662921348314608 L98.87640449438203 19.662921348314608 M1.1235955056179776 20.786516853932586 L2.247191011235955 20.786516853932586 M4.49438202247191 20.786516853932586 L7.865168539325843 20.786516853932586 M10.112359550561798 20.786516853932586 L13.483146067415731 20.786516853932586 M14.606741573033709 20.786516853932586 L15.730337078651687 20.786516853932586 M17.97752808988764 20.786516853932586 L19.10112359550562 20.786516853932586 M20.224719101123597 20.786516853932586 L22.471910112359552 20.786516853932586 M23.59550561797753 20.786516853932586 L28.08988764044944 20.786516853932586 M29.213483146067418 20.786516853932586 L34.831460674157306 20.786516853932586 M35.95505617977528 20.786516853932586 L37.07865168539326 20.786516853932586 M38.20224719101124 20.786516853932586 L40.449438202247194 20.786516853932586 M41.57303370786517 20.786516853932586 L46.06741573033708 20.786516853932586 M48.31460674157304 20.786516853932586 L49.438202247191015 20.786516853932586 M50.56179775280899 20.786516853932586 L51.68539325842697 20.786516853932586 M53.932584269662925 20.786516853932586 L56.17977528089888 20.786516853932586 M57.30337078651686 20.786516853932586 L59.55056179775281 20.786516853932586 M62.921348314606746 20.786516853932586 L68.53932584269663 20.786516853932586 M69.66292134831461 20.786516853932586 L71.91011235955057 20.786516853932586 M77.52808988764045 20.786516853932586 L80.89887640449439 20.786516853932586 M82.02247191011236 20.786516853932586 L84.26966292134833 20.786516853932586 M85.3932584269663 20.786516853932586 L86.51685393258427 20.786516853932586 M89.88764044943821 20.786516853932586 L92.13483146067416 20.786516853932586 M93.25842696629215 20.786516853932586 L96.62921348314607 20.786516853932586 M5.617977528089888 21.910112359550563 L6.741573033707866 21.910112359550563 M10.112359550561798 21.910112359550563 L12.359550561797754 21.910112359550563 M13.483146067415731 21.910112359550563 L14.606741573033709 21.910112359550563 M15.730337078651687 21.910112359550563 L16.853932584269664 21.910112359550563 M17.97752808988764 21.910112359550563 L20.224719101123597 21.910112359550563 M22.471910112359552 21.910112359550563 L24.719101123595507 21.910112359550563 M25.842696629213485 21.910112359550563 L26.966292134831463 21.910112359550563 M28.08988764044944 21.910112359550563 L29.213483146067418 21.910112359550563 M30.337078651685395 21.910112359550563 L31.460674157303373 21.910112359550563 M32.58426966292135 21.910112359550563 L35.95505617977528 21.910112359550563 M37.07865168539326 21.910112359550563 L38.20224719101124 21.910112359550563 M40.449438202247194 21.910112359550563 L42.69662921348315 21.910112359550563 M43.82022471910113 21.910112359550563 L44.943820224719104 21.910112359550563 M46.06741573033708 21.910112359550563 L48.31460674157304 21.910112359550563 M49.438202247191015 21.910112359550563 L50.56179775280899 21.910112359550563 M52.80898876404495 21.910112359550563 L55.0561797752809 21.910112359550563 M56.17977528089888 21.910112359550563 L61.79775280898877 21.910112359550563 M64.04494382022472 21.910112359550563 L65.1685393258427 21.910112359550563 M68.53932584269663 21.910112359550563 L73.03370786516854 21.910112359550563 M76.40449438202248 21.910112359550563 L80.89887640449439 21.910112359550563 M82.02247191011236 21.910112359550563 L83.14606741573034 21.910112359550563 M84.26966292134833 21.910112359550563 L85.3932584269663 21.910112359550563 M86.51685393258427 21.910112359550563 L87.64044943820225 21.910112359550563 M92.13483146067416 21.910112359550563 L95.50561797752809 21.910112359550563 M1.1235955056179776 23.03370786516854 L2.247191011235955 23.03370786516854 M4.49438202247191 23.03370786516854 L7.865168539325843 23.03370786516854 M10.112359550561798 23.03370786516854 L11.235955056179776 23.03370786516854 M13.483146067415731 23.03370786516854 L14.606741573033709 23.03370786516854 M15.730337078651687 23.03370786516854 L16.853932584269664 23.03370786516854 M20.224719101123597 23.03370786516854 L22.471910112359552 23.03370786516854 M24.719101123595507 23.03370786516854 L25.842696629213485 23.03370786516854 M30.337078651685395 23.03370786516854 L33.70786516853933 23.03370786516854 M34.831460674157306 23.03370786516854 L38.20224719101124 23.03370786516854 M39.325842696629216 23.03370786516854 L43.82022471910113 23.03370786516854 M46.06741573033708 23.03370786516854 L47.19101123595506 23.03370786516854 M48.31460674157304 23.03370786516854 L49.438202247191015 23.03370786516854 M52.80898876404495 23.03370786516854 L55.0561797752809 23.03370786516854 M56.17977528089888 23.03370786516854 L57.30337078651686 23.03370786516854 M59.55056179775281 23.03370786516854 L60.67415730337079 23.03370786516854 M61.79775280898877 23.03370786516854 L62.921348314606746 23.03370786516854 M67.41573033707866 23.03370786516854 L71.91011235955057 23.03370786516854 M73.03370786516854 23.03370786516854 L75.2808988764045 23.03370786516854 M76.40449438202248 23.03370786516854 L79.77528089887642 23.03370786516854 M82.02247191011236 23.03370786516854 L83.14606741573034 23.03370786516854 M84.26966292134833 23.03370786516854 L86.51685393258427 23.03370786516854 M89.88764044943821 23.03370786516854 L93.25842696629215 23.03370786516854 M94.38202247191012 23.03370786516854 L97.75280898876406 23.03370786516854 M0 24.15730337078652 L1.1235955056179776 24.15730337078652 M2.247191011235955 24.15730337078652 L6.741573033707866 24.15730337078652 M7.865168539325843 24.15730337078652 L11.235955056179776 24.15730337078652 M12.359550561797754 24.15730337078652 L15.730337078651687 24.15730337078652 M16.853932584269664 24.15730337078652 L20.224719101123597 24.15730337078652 M22.471910112359552 24.15730337078652 L23.59550561797753 24.15730337078652 M25.842696629213485 24.15730337078652 L26.966292134831463 24.15730337078652 M28.08988764044944 24.15730337078652 L30.337078651685395 24.15730337078652 M32.58426966292135 24.15730337078652 L35.95505617977528 24.15730337078652 M39.325842696629216 24.15730337078652 L40.449438202247194 24.15730337078652 M41.57303370786517 24.15730337078652 L42.69662921348315 24.15730337078652 M44.943820224719104 24.15730337078652 L48.31460674157304 24.15730337078652 M49.438202247191015 24.15730337078652 L50.56179775280899 24.15730337078652 M55.0561797752809 24.15730337078652 L56.17977528089888 24.15730337078652 M58.426966292134836 24.15730337078652 L59.55056179775281 24.15730337078652 M61.79775280898877 24.15730337078652 L68.53932584269663 24.15730337078652 M74.15730337078652 24.15730337078652 L75.2808988764045 24.15730337078652 M76.40449438202248 24.15730337078652 L78.65168539325843 24.15730337078652 M79.77528089887642 24.15730337078652 L80.89887640449439 24.15730337078652 M84.26966292134833 24.15730337078652 L85.3932584269663 24.15730337078652 M87.64044943820225 24.15730337078652 L88.76404494382024 24.15730337078652 M89.88764044943821 24.15730337078652 L93.25842696629215 24.15730337078652 M94.38202247191012 24.15730337078652 L96.62921348314607 24.15730337078652 M97.75280898876406 24.15730337078652 L100 24.15730337078652 M2.247191011235955 25.280898876404496 L5.617977528089888 25.280898876404496 M6.741573033707866 25.280898876404496 L8.98876404494382 25.280898876404496 M10.112359550561798 25.280898876404496 L11.235955056179776 25.280898876404496 M12.359550561797754 25.280898876404496 L13.483146067415731 25.280898876404496 M19.10112359550562 25.280898876404496 L20.224719101123597 25.280898876404496 M21.348314606741575 25.280898876404496 L28.08988764044944 25.280898876404496 M30.337078651685395 25.280898876404496 L41.57303370786517 25.280898876404496 M46.06741573033708 25.280898876404496 L48.31460674157304 25.280898876404496 M49.438202247191015 25.280898876404496 L51.68539325842697 25.280898876404496 M53.932584269662925 25.280898876404496 L57.30337078651686 25.280898876404496 M59.55056179775281 25.280898876404496 L60.67415730337079 25.280898876404496 M65.1685393258427 25.280898876404496 L67.41573033707866 25.280898876404496 M69.66292134831461 25.280898876404496 L71.91011235955057 25.280898876404496 M75.2808988764045 25.280898876404496 L76.40449438202248 25.280898876404496 M77.52808988764045 25.280898876404496 L79.77528089887642 25.280898876404496 M82.02247191011236 25.280898876404496 L87.64044943820225 25.280898876404496 M88.76404494382024 25.280898876404496 L91.01123595505618 25.280898876404496 M94.38202247191012 25.280898876404496 L96.62921348314607 25.280898876404496 M0 26.404494382022474 L2.247191011235955 26.404494382022474 M3.370786516853933 26.404494382022474 L4.49438202247191 26.404494382022474 M5.617977528089888 26.404494382022474 L6.741573033707866 26.404494382022474 M7.865168539325843 26.404494382022474 L12.359550561797754 26.404494382022474 M13.483146067415731 26.404494382022474 L16.853932584269664 26.404494382022474 M17.97752808988764 26.404494382022474 L22.471910112359552 26.404494382022474 M23.59550561797753 26.404494382022474 L24.719101123595507 26.404494382022474 M26.966292134831463 26.404494382022474 L30.337078651685395 26.404494382022474 M31.460674157303373 26.404494382022474 L37.07865168539326 26.404494382022474 M38.20224719101124 26.404494382022474 L39.325842696629216 26.404494382022474 M42.69662921348315 26.404494382022474 L47.19101123595506 26.404494382022474 M48.31460674157304 26.404494382022474 L52.80898876404495 26.404494382022474 M56.17977528089888 26.404494382022474 L60.67415730337079 26.404494382022474 M62.921348314606746 26.404494382022474 L67.41573033707866 26.404494382022474 M68.53932584269663 26.404494382022474 L74.15730337078652 26.404494382022474 M75.2808988764045 26.404494382022474 L77.52808988764045 26.404494382022474 M79.77528089887642 26.404494382022474 L80.89887640449439 26.404494382022474 M82.02247191011236 26.404494382022474 L83.14606741573034 26.404494382022474 M84.26966292134833 26.404494382022474 L88.76404494382024 26.404494382022474 M89.88764044943821 26.404494382022474 L92.13483146067416 26.404494382022474 M93.25842696629215 26.404494382022474 L96.62921348314607 26.404494382022474 M97.75280898876406 26.404494382022474 L100 26.404494382022474 M2.247191011235955 27.52808988764045 L3.370786516853933 27.52808988764045 M4.49438202247191 27.52808988764045 L5.617977528089888 27.52808988764045 M6.741573033707866 27.52808988764045 L7.865168539325843 27.52808988764045 M8.98876404494382 27.52808988764045 L10.112359550561798 27.52808988764045 M11.235955056179776 27.52808988764045 L12.359550561797754 27.52808988764045 M13.483146067415731 27.52808988764045 L15.730337078651687 27.52808988764045 M16.853932584269664 27.52808988764045 L17.97752808988764 27.52808988764045 M19.10112359550562 27.52808988764045 L20.224719101123597 27.52808988764045 M21.348314606741575 27.52808988764045 L22.471910112359552 27.52808988764045 M25.842696629213485 27.52808988764045 L26.966292134831463 27.52808988764045 M31.460674157303373 27.52808988764045 L35.95505617977528 27.52808988764045 M38.20224719101124 27.52808988764045 L42.69662921348315 27.52808988764045 M48.31460674157304 27.52808988764045 L49.438202247191015 27.52808988764045 M51.68539325842697 27.52808988764045 L55.0561797752809 27.52808988764045 M56.17977528089888 27.52808988764045 L57.30337078651686 27.52808988764045 M59.55056179775281 27.52808988764045 L60.67415730337079 27.52808988764045 M61.79775280898877 27.52808988764045 L64.04494382022472 27.52808988764045 M65.1685393258427 27.52808988764045 L66.29213483146069 27.52808988764045 M67.41573033707866 27.52808988764045 L75.2808988764045 27.52808988764045 M76.40449438202248 27.52808988764045 L77.52808988764045 27.52808988764045 M78.65168539325843 27.52808988764045 L79.77528089887642 27.52808988764045 M82.02247191011236 27.52808988764045 L83.14606741573034 27.52808988764045 M84.26966292134833 27.52808988764045 L85.3932584269663 27.52808988764045 M86.51685393258427 27.52808988764045 L87.64044943820225 27.52808988764045 M88.76404494382024 27.52808988764045 L95.50561797752809 27.52808988764045 M97.75280898876406 27.52808988764045 L98.87640449438203 27.52808988764045 M0 28.65168539325843 L2.247191011235955 28.65168539325843 M3.370786516853933 28.65168539325843 L5.617977528089888 28.65168539325843 M7.865168539325843 28.65168539325843 L10.112359550561798 28.65168539325843 M11.235955056179776 28.65168539325843 L12.359550561797754 28.65168539325843 M15.730337078651687 28.65168539325843 L16.853932584269664 28.65168539325843 M23.59550561797753 28.65168539325843 L25.842696629213485 28.65168539325843 M28.08988764044944 28.65168539325843 L29.213483146067418 28.65168539325843 M30.337078651685395 28.65168539325843 L32.58426966292135 28.65168539325843 M34.831460674157306 28.65168539325843 L35.95505617977528 28.65168539325843 M37.07865168539326 28.65168539325843 L38.20224719101124 28.65168539325843 M39.325842696629216 28.65168539325843 L40.449438202247194 28.65168539325843 M46.06741573033708 28.65168539325843 L47.19101123595506 28.65168539325843 M48.31460674157304 28.65168539325843 L51.68539325842697 28.65168539325843 M52.80898876404495 28.65168539325843 L56.17977528089888 28.65168539325843 M58.426966292134836 28.65168539325843 L61.79775280898877 28.65168539325843 M62.921348314606746 28.65168539325843 L67.41573033707866 28.65168539325843 M68.53932584269663 28.65168539325843 L69.66292134831461 28.65168539325843 M74.15730337078652 28.65168539325843 L79.77528089887642 28.65168539325843 M80.89887640449439 28.65168539325843 L82.02247191011236 28.65168539325843 M83.14606741573034 28.65168539325843 L84.26966292134833 28.65168539325843 M87.64044943820225 28.65168539325843 L88.76404494382024 28.65168539325843 M95.50561797752809 28.65168539325843 L96.62921348314607 28.65168539325843 M97.75280898876406 28.65168539325843 L98.87640449438203 28.65168539325843 M2.247191011235955 29.775280898876407 L4.49438202247191 29.775280898876407 M6.741573033707866 29.775280898876407 L10.112359550561798 29.775280898876407 M15.730337078651687 29.775280898876407 L17.97752808988764 29.775280898876407 M19.10112359550562 29.775280898876407 L20.224719101123597 29.775280898876407 M21.348314606741575 29.775280898876407 L22.471910112359552 29.775280898876407 M34.831460674157306 29.775280898876407 L37.07865168539326 29.775280898876407 M38.20224719101124 29.775280898876407 L39.325842696629216 29.775280898876407 M40.449438202247194 29.775280898876407 L46.06741573033708 29.775280898876407 M47.19101123595506 29.775280898876407 L48.31460674157304 29.775280898876407 M49.438202247191015 29.775280898876407 L50.56179775280899 29.775280898876407 M51.68539325842697 29.775280898876407 L53.932584269662925 29.775280898876407 M55.0561797752809 29.775280898876407 L58.426966292134836 29.775280898876407 M64.04494382022472 29.775280898876407 L66.29213483146069 29.775280898876407 M69.66292134831461 29.775280898876407 L74.15730337078652 29.775280898876407 M75.2808988764045 29.775280898876407 L76.40449438202248 29.775280898876407 M78.65168539325843 29.775280898876407 L85.3932584269663 29.775280898876407 M86.51685393258427 29.775280898876407 L87.64044943820225 29.775280898876407 M88.76404494382024 29.775280898876407 L89.88764044943821 29.775280898876407 M93.25842696629215 29.775280898876407 L97.75280898876406 29.775280898876407 M1.1235955056179776 30.898876404494384 L5.617977528089888 30.898876404494384 M7.865168539325843 30.898876404494384 L10.112359550561798 30.898876404494384 M11.235955056179776 30.898876404494384 L14.606741573033709 30.898876404494384 M15.730337078651687 30.898876404494384 L16.853932584269664 30.898876404494384 M17.97752808988764 30.898876404494384 L19.10112359550562 30.898876404494384 M22.471910112359552 30.898876404494384 L24.719101123595507 30.898876404494384 M25.842696629213485 30.898876404494384 L30.337078651685395 30.898876404494384 M31.460674157303373 30.898876404494384 L32.58426966292135 30.898876404494384 M35.95505617977528 30.898876404494384 L40.449438202247194 30.898876404494384 M42.69662921348315 30.898876404494384 L43.82022471910113 30.898876404494384 M47.19101123595506 30.898876404494384 L49.438202247191015 30.898876404494384 M51.68539325842697 30.898876404494384 L52.80898876404495 30.898876404494384 M56.17977528089888 30.898876404494384 L57.30337078651686 30.898876404494384 M59.55056179775281 30.898876404494384 L64.04494382022472 30.898876404494384 M65.1685393258427 30.898876404494384 L66.29213483146069 30.898876404494384 M68.53932584269663 30.898876404494384 L69.66292134831461 30.898876404494384 M70.7865168539326 30.898876404494384 L71.91011235955057 30.898876404494384 M73.03370786516854 30.898876404494384 L75.2808988764045 30.898876404494384 M76.40449438202248 30.898876404494384 L77.52808988764045 30.898876404494384 M85.3932584269663 30.898876404494384 L88.76404494382024 30.898876404494384 M91.01123595505618 30.898876404494384 L93.25842696629215 30.898876404494384 M94.38202247191012 30.898876404494384 L96.62921348314607 30.898876404494384 M97.75280898876406 30.898876404494384 L98.87640449438203 30.898876404494384 M1.1235955056179776 32.02247191011236 L10.112359550561798 32.02247191011236 M13.483146067415731 32.02247191011236 L14.606741573033709 32.02247191011236 M15.730337078651687 32.02247191011236 L16.853932584269664 32.02247191011236 M17.97752808988764 32.02247191011236 L22.471910112359552 32.02247191011236 M24.719101123595507 32.02247191011236 L25.842696629213485 32.02247191011236 M31.460674157303373 32.02247191011236 L38.20224719101124 32.02247191011236 M40.449438202247194 32.02247191011236 L42.69662921348315 32.02247191011236 M46.06741573033708 32.02247191011236 L47.19101123595506 32.02247191011236 M52.80898876404495 32.02247191011236 L56.17977528089888 32.02247191011236 M59.55056179775281 32.02247191011236 L66.29213483146069 32.02247191011236 M67.41573033707866 32.02247191011236 L69.66292134831461 32.02247191011236 M70.7865168539326 32.02247191011236 L74.15730337078652 32.02247191011236 M77.52808988764045 32.02247191011236 L78.65168539325843 32.02247191011236 M80.89887640449439 32.02247191011236 L83.14606741573034 32.02247191011236 M84.26966292134833 32.02247191011236 L86.51685393258427 32.02247191011236 M87.64044943820225 32.02247191011236 L88.76404494382024 32.02247191011236 M89.88764044943821 32.02247191011236 L95.50561797752809 32.02247191011236 M96.62921348314607 32.02247191011236 L98.87640449438203 32.02247191011236 M0 33.14606741573034 L2.247191011235955 33.14606741573034 M4.49438202247191 33.14606741573034 L5.617977528089888 33.14606741573034 M8.98876404494382 33.14606741573034 L13.483146067415731 33.14606741573034 M14.606741573033709 33.14606741573034 L15.730337078651687 33.14606741573034 M17.97752808988764 33.14606741573034 L19.10112359550562 33.14606741573034 M21.348314606741575 33.14606741573034 L24.719101123595507 33.14606741573034 M26.966292134831463 33.14606741573034 L30.337078651685395 33.14606741573034 M31.460674157303373 33.14606741573034 L32.58426966292135 33.14606741573034 M35.95505617977528 33.14606741573034 L37.07865168539326 33.14606741573034 M38.20224719101124 33.14606741573034 L39.325842696629216 33.14606741573034 M41.57303370786517 33.14606741573034 L42.69662921348315 33.14606741573034 M43.82022471910113 33.14606741573034 L44.943820224719104 33.14606741573034 M46.06741573033708 33.14606741573034 L49.438202247191015 33.14606741573034 M53.932584269662925 33.14606741573034 L56.17977528089888 33.14606741573034 M59.55056179775281 33.14606741573034 L61.79775280898877 33.14606741573034 M65.1685393258427 33.14606741573034 L66.29213483146069 33.14606741573034 M70.7865168539326 33.14606741573034 L71.91011235955057 33.14606741573034 M74.15730337078652 33.14606741573034 L75.2808988764045 33.14606741573034 M76.40449438202248 33.14606741573034 L78.65168539325843 33.14606741573034 M79.77528089887642 33.14606741573034 L82.02247191011236 33.14606741573034 M83.14606741573034 33.14606741573034 L86.51685393258427 33.14606741573034 M87.64044943820225 33.14606741573034 L91.01123595505618 33.14606741573034 M94.38202247191012 33.14606741573034 L95.50561797752809 33.14606741573034 M98.87640449438203 33.14606741573034 L100 33.14606741573034 M1.1235955056179776 34.26966292134831 L5.617977528089888 34.26966292134831 M6.741573033707866 34.26966292134831 L7.865168539325843 34.26966292134831 M8.98876404494382 34.26966292134831 L10.112359550561798 34.26966292134831 M11.235955056179776 34.26966292134831 L12.359550561797754 34.26966292134831 M13.483146067415731 34.26966292134831 L15.730337078651687 34.26966292134831 M16.853932584269664 34.26966292134831 L20.224719101123597 34.26966292134831 M24.719101123595507 34.26966292134831 L25.842696629213485 34.26966292134831 M26.966292134831463 34.26966292134831 L29.213483146067418 34.26966292134831 M31.460674157303373 34.26966292134831 L32.58426966292135 34.26966292134831 M33.70786516853933 34.26966292134831 L34.831460674157306 34.26966292134831 M35.95505617977528 34.26966292134831 L37.07865168539326 34.26966292134831 M38.20224719101124 34.26966292134831 L40.449438202247194 34.26966292134831 M44.943820224719104 34.26966292134831 L47.19101123595506 34.26966292134831 M50.56179775280899 34.26966292134831 L51.68539325842697 34.26966292134831 M52.80898876404495 34.26966292134831 L56.17977528089888 34.26966292134831 M57.30337078651686 34.26966292134831 L61.79775280898877 34.26966292134831 M62.921348314606746 34.26966292134831 L64.04494382022472 34.26966292134831 M65.1685393258427 34.26966292134831 L71.91011235955057 34.26966292134831 M76.40449438202248 34.26966292134831 L80.89887640449439 34.26966292134831 M83.14606741573034 34.26966292134831 L86.51685393258427 34.26966292134831 M89.88764044943821 34.26966292134831 L91.01123595505618 34.26966292134831 M92.13483146067416 34.26966292134831 L93.25842696629215 34.26966292134831 M94.38202247191012 34.26966292134831 L96.62921348314607 34.26966292134831 M4.49438202247191 35.3932584269663 L5.617977528089888 35.3932584269663 M8.98876404494382 35.3932584269663 L14.606741573033709 35.3932584269663 M16.853932584269664 35.3932584269663 L22.471910112359552 35.3932584269663 M23.59550561797753 35.3932584269663 L24.719101123595507 35.3932584269663 M25.842696629213485 35.3932584269663 L28.08988764044944 35.3932584269663 M30.337078651685395 35.3932584269663 L32.58426966292135 35.3932584269663 M35.95505617977528 35.3932584269663 L39.325842696629216 35.3932584269663 M41.57303370786517 35.3932584269663 L43.82022471910113 35.3932584269663 M47.19101123595506 35.3932584269663 L49.438202247191015 35.3932584269663 M50.56179775280899 35.3932584269663 L53.932584269662925 35.3932584269663 M55.0561797752809 35.3932584269663 L59.55056179775281 35.3932584269663 M60.67415730337079 35.3932584269663 L61.79775280898877 35.3932584269663 M65.1685393258427 35.3932584269663 L66.29213483146069 35.3932584269663 M68.53932584269663 35.3932584269663 L69.66292134831461 35.3932584269663 M70.7865168539326 35.3932584269663 L78.65168539325843 35.3932584269663 M82.02247191011236 35.3932584269663 L83.14606741573034 35.3932584269663 M85.3932584269663 35.3932584269663 L87.64044943820225 35.3932584269663 M88.76404494382024 35.3932584269663 L91.01123595505618 35.3932584269663 M94.38202247191012 35.3932584269663 L95.50561797752809 35.3932584269663 M0 36.51685393258427 L2.247191011235955 36.51685393258427 M3.370786516853933 36.51685393258427 L10.112359550561798 36.51685393258427 M11.235955056179776 36.51685393258427 L13.483146067415731 36.51685393258427 M15.730337078651687 36.51685393258427 L16.853932584269664 36.51685393258427 M21.348314606741575 36.51685393258427 L23.59550561797753 36.51685393258427 M29.213483146067418 36.51685393258427 L30.337078651685395 36.51685393258427 M31.460674157303373 36.51685393258427 L38.20224719101124 36.51685393258427 M39.325842696629216 36.51685393258427 L41.57303370786517 36.51685393258427 M42.69662921348315 36.51685393258427 L43.82022471910113 36.51685393258427 M48.31460674157304 36.51685393258427 L49.438202247191015 36.51685393258427 M50.56179775280899 36.51685393258427 L52.80898876404495 36.51685393258427 M53.932584269662925 36.51685393258427 L55.0561797752809 36.51685393258427 M59.55056179775281 36.51685393258427 L66.29213483146069 36.51685393258427 M68.53932584269663 36.51685393258427 L71.91011235955057 36.51685393258427 M73.03370786516854 36.51685393258427 L74.15730337078652 36.51685393258427 M76.40449438202248 36.51685393258427 L77.52808988764045 36.51685393258427 M78.65168539325843 36.51685393258427 L79.77528089887642 36.51685393258427 M82.02247191011236 36.51685393258427 L87.64044943820225 36.51685393258427 M88.76404494382024 36.51685393258427 L96.62921348314607 36.51685393258427 M2.247191011235955 37.64044943820225 L3.370786516853933 37.64044943820225 M4.49438202247191 37.64044943820225 L5.617977528089888 37.64044943820225 M7.865168539325843 37.64044943820225 L10.112359550561798 37.64044943820225 M13.483146067415731 37.64044943820225 L15.730337078651687 37.64044943820225 M19.10112359550562 37.64044943820225 L20.224719101123597 37.64044943820225 M22.471910112359552 37.64044943820225 L23.59550561797753 37.64044943820225 M24.719101123595507 37.64044943820225 L29.213483146067418 37.64044943820225 M33.70786516853933 37.64044943820225 L34.831460674157306 37.64044943820225 M35.95505617977528 37.64044943820225 L39.325842696629216 37.64044943820225 M41.57303370786517 37.64044943820225 L42.69662921348315 37.64044943820225 M47.19101123595506 37.64044943820225 L50.56179775280899 37.64044943820225 M52.80898876404495 37.64044943820225 L56.17977528089888 37.64044943820225 M61.79775280898877 37.64044943820225 L62.921348314606746 37.64044943820225 M66.29213483146069 37.64044943820225 L68.53932584269663 37.64044943820225 M69.66292134831461 37.64044943820225 L70.7865168539326 37.64044943820225 M74.15730337078652 37.64044943820225 L75.2808988764045 37.64044943820225 M76.40449438202248 37.64044943820225 L80.89887640449439 37.64044943820225 M82.02247191011236 37.64044943820225 L83.14606741573034 37.64044943820225 M84.26966292134833 37.64044943820225 L86.51685393258427 37.64044943820225 M87.64044943820225 37.64044943820225 L88.76404494382024 37.64044943820225 M92.13483146067416 37.64044943820225 L96.62921348314607 37.64044943820225 M97.75280898876406 37.64044943820225 L98.87640449438203 37.64044943820225 M0 38.764044943820224 L1.1235955056179776 38.764044943820224 M2.247191011235955 38.764044943820224 L11.235955056179776 38.764044943820224 M13.483146067415731 38.764044943820224 L14.606741573033709 38.764044943820224 M15.730337078651687 38.764044943820224 L16.853932584269664 38.764044943820224 M19.10112359550562 38.764044943820224 L20.224719101123597 38.764044943820224 M21.348314606741575 38.764044943820224 L25.842696629213485 38.764044943820224 M26.966292134831463 38.764044943820224 L30.337078651685395 38.764044943820224 M31.460674157303373 38.764044943820224 L34.831460674157306 38.764044943820224 M35.95505617977528 38.764044943820224 L38.20224719101124 38.764044943820224 M39.325842696629216 38.764044943820224 L40.449438202247194 38.764044943820224 M42.69662921348315 38.764044943820224 L47.19101123595506 38.764044943820224 M48.31460674157304 38.764044943820224 L49.438202247191015 38.764044943820224 M50.56179775280899 38.764044943820224 L55.0561797752809 38.764044943820224 M56.17977528089888 38.764044943820224 L59.55056179775281 38.764044943820224 M62.921348314606746 38.764044943820224 L65.1685393258427 38.764044943820224 M67.41573033707866 38.764044943820224 L68.53932584269663 38.764044943820224 M69.66292134831461 38.764044943820224 L71.91011235955057 38.764044943820224 M76.40449438202248 38.764044943820224 L77.52808988764045 38.764044943820224 M78.65168539325843 38.764044943820224 L82.02247191011236 38.764044943820224 M83.14606741573034 38.764044943820224 L84.26966292134833 38.764044943820224 M85.3932584269663 38.764044943820224 L86.51685393258427 38.764044943820224 M88.76404494382024 38.764044943820224 L89.88764044943821 38.764044943820224 M94.38202247191012 38.764044943820224 L95.50561797752809 38.764044943820224 M97.75280898876406 38.764044943820224 L98.87640449438203 38.764044943820224 M1.1235955056179776 39.88764044943821 L4.49438202247191 39.88764044943821 M8.98876404494382 39.88764044943821 L14.606741573033709 39.88764044943821 M15.730337078651687 39.88764044943821 L19.10112359550562 39.88764044943821 M20.224719101123597 39.88764044943821 L21.348314606741575 39.88764044943821 M22.471910112359552 39.88764044943821 L23.59550561797753 39.88764044943821 M24.719101123595507 39.88764044943821 L25.842696629213485 39.88764044943821 M26.966292134831463 39.88764044943821 L31.460674157303373 39.88764044943821 M32.58426966292135 39.88764044943821 L37.07865168539326 39.88764044943821 M41.57303370786517 39.88764044943821 L44.943820224719104 39.88764044943821 M46.06741573033708 39.88764044943821 L48.31460674157304 39.88764044943821 M49.438202247191015 39.88764044943821 L51.68539325842697 39.88764044943821 M53.932584269662925 39.88764044943821 L58.426966292134836 39.88764044943821 M62.921348314606746 39.88764044943821 L67.41573033707866 39.88764044943821 M70.7865168539326 39.88764044943821 L73.03370786516854 39.88764044943821 M76.40449438202248 39.88764044943821 L77.52808988764045 39.88764044943821 M82.02247191011236 39.88764044943821 L83.14606741573034 39.88764044943821 M85.3932584269663 39.88764044943821 L86.51685393258427 39.88764044943821 M87.64044943820225 39.88764044943821 L89.88764044943821 39.88764044943821 M94.38202247191012 39.88764044943821 L96.62921348314607 39.88764044943821 M97.75280898876406 39.88764044943821 L100 39.88764044943821 M1.1235955056179776 41.01123595505618 L2.247191011235955 41.01123595505618 M3.370786516853933 41.01123595505618 L5.617977528089888 41.01123595505618 M6.741573033707866 41.01123595505618 L11.235955056179776 41.01123595505618 M12.359550561797754 41.01123595505618 L15.730337078651687 41.01123595505618 M16.853932584269664 41.01123595505618 L17.97752808988764 41.01123595505618 M20.224719101123597 41.01123595505618 L23.59550561797753 41.01123595505618 M24.719101123595507 41.01123595505618 L26.966292134831463 41.01123595505618 M28.08988764044944 41.01123595505618 L37.07865168539326 41.01123595505618 M38.20224719101124 41.01123595505618 L42.69662921348315 41.01123595505618 M47.19101123595506 41.01123595505618 L49.438202247191015 41.01123595505618 M51.68539325842697 41.01123595505618 L55.0561797752809 41.01123595505618 M56.17977528089888 41.01123595505618 L57.30337078651686 41.01123595505618 M59.55056179775281 41.01123595505618 L61.79775280898877 41.01123595505618 M67.41573033707866 41.01123595505618 L69.66292134831461 41.01123595505618 M70.7865168539326 41.01123595505618 L71.91011235955057 41.01123595505618 M74.15730337078652 41.01123595505618 L75.2808988764045 41.01123595505618 M76.40449438202248 41.01123595505618 L77.52808988764045 41.01123595505618 M80.89887640449439 41.01123595505618 L85.3932584269663 41.01123595505618 M87.64044943820225 41.01123595505618 L88.76404494382024 41.01123595505618 M89.88764044943821 41.01123595505618 L92.13483146067416 41.01123595505618 M93.25842696629215 41.01123595505618 L95.50561797752809 41.01123595505618 M96.62921348314607 41.01123595505618 L98.87640449438203 41.01123595505618 M0 42.134831460674164 L1.1235955056179776 42.134831460674164 M2.247191011235955 42.134831460674164 L4.49438202247191 42.134831460674164 M7.865168539325843 42.134831460674164 L16.853932584269664 42.134831460674164 M19.10112359550562 42.134831460674164 L20.224719101123597 42.134831460674164 M22.471910112359552 42.134831460674164 L25.842696629213485 42.134831460674164 M26.966292134831463 42.134831460674164 L28.08988764044944 42.134831460674164 M30.337078651685395 42.134831460674164 L31.460674157303373 42.134831460674164 M35.95505617977528 42.134831460674164 L37.07865168539326 42.134831460674164 M38.20224719101124 42.134831460674164 L39.325842696629216 42.134831460674164 M41.57303370786517 42.134831460674164 L42.69662921348315 42.134831460674164 M43.82022471910113 42.134831460674164 L50.56179775280899 42.134831460674164 M52.80898876404495 42.134831460674164 L55.0561797752809 42.134831460674164 M57.30337078651686 42.134831460674164 L59.55056179775281 42.134831460674164 M61.79775280898877 42.134831460674164 L65.1685393258427 42.134831460674164 M66.29213483146069 42.134831460674164 L67.41573033707866 42.134831460674164 M69.66292134831461 42.134831460674164 L70.7865168539326 42.134831460674164 M74.15730337078652 42.134831460674164 L75.2808988764045 42.134831460674164 M77.52808988764045 42.134831460674164 L78.65168539325843 42.134831460674164 M79.77528089887642 42.134831460674164 L82.02247191011236 42.134831460674164 M83.14606741573034 42.134831460674164 L86.51685393258427 42.134831460674164 M87.64044943820225 42.134831460674164 L88.76404494382024 42.134831460674164 M89.88764044943821 42.134831460674164 L92.13483146067416 42.134831460674164 M93.25842696629215 42.134831460674164 L95.50561797752809 42.134831460674164 M96.62921348314607 42.134831460674164 L98.87640449438203 42.134831460674164 M0 43.258426966292134 L1.1235955056179776 43.258426966292134 M2.247191011235955 43.258426966292134 L3.370786516853933 43.258426966292134 M4.49438202247191 43.258426966292134 L8.98876404494382 43.258426966292134 M10.112359550561798 43.258426966292134 L11.235955056179776 43.258426966292134 M12.359550561797754 43.258426966292134 L20.224719101123597 43.258426966292134 M21.348314606741575 43.258426966292134 L23.59550561797753 43.258426966292134 M25.842696629213485 43.258426966292134 L29.213483146067418 43.258426966292134 M32.58426966292135 43.258426966292134 L33.70786516853933 43.258426966292134 M35.95505617977528 43.258426966292134 L38.20224719101124 43.258426966292134 M42.69662921348315 43.258426966292134 L44.943820224719104 43.258426966292134 M47.19101123595506 43.258426966292134 L48.31460674157304 43.258426966292134 M55.0561797752809 43.258426966292134 L60.67415730337079 43.258426966292134 M64.04494382022472 43.258426966292134 L67.41573033707866 43.258426966292134 M69.66292134831461 43.258426966292134 L73.03370786516854 43.258426966292134 M75.2808988764045 43.258426966292134 L77.52808988764045 43.258426966292134 M78.65168539325843 43.258426966292134 L86.51685393258427 43.258426966292134 M91.01123595505618 43.258426966292134 L96.62921348314607 43.258426966292134 M98.87640449438203 43.258426966292134 L100 43.258426966292134 M0 44.38202247191012 L2.247191011235955 44.38202247191012 M3.370786516853933 44.38202247191012 L6.741573033707866 44.38202247191012 M11.235955056179776 44.38202247191012 L13.483146067415731 44.38202247191012 M14.606741573033709 44.38202247191012 L16.853932584269664 44.38202247191012 M20.224719101123597 44.38202247191012 L22.471910112359552 44.38202247191012 M24.719101123595507 44.38202247191012 L25.842696629213485 44.38202247191012 M28.08988764044944 44.38202247191012 L29.213483146067418 44.38202247191012 M30.337078651685395 44.38202247191012 L31.460674157303373 44.38202247191012 M33.70786516853933 44.38202247191012 L37.07865168539326 44.38202247191012 M38.20224719101124 44.38202247191012 L39.325842696629216 44.38202247191012 M41.57303370786517 44.38202247191012 L43.82022471910113 44.38202247191012 M44.943820224719104 44.38202247191012 L46.06741573033708 44.38202247191012 M49.438202247191015 44.38202247191012 L52.80898876404495 44.38202247191012 M53.932584269662925 44.38202247191012 L58.426966292134836 44.38202247191012 M59.55056179775281 44.38202247191012 L61.79775280898877 44.38202247191012 M62.921348314606746 44.38202247191012 L67.41573033707866 44.38202247191012 M73.03370786516854 44.38202247191012 L75.2808988764045 44.38202247191012 M76.40449438202248 44.38202247191012 L78.65168539325843 44.38202247191012 M85.3932584269663 44.38202247191012 L86.51685393258427 44.38202247191012 M88.76404494382024 44.38202247191012 L89.88764044943821 44.38202247191012 M93.25842696629215 44.38202247191012 L96.62921348314607 44.38202247191012 M97.75280898876406 44.38202247191012 L100 44.38202247191012 M0 45.50561797752809 L3.370786516853933 45.50561797752809 M4.49438202247191 45.50561797752809 L5.617977528089888 45.50561797752809 M6.741573033707866 45.50561797752809 L7.865168539325843 45.50561797752809 M10.112359550561798 45.50561797752809 L11.235955056179776 45.50561797752809 M13.483146067415731 45.50561797752809 L20.224719101123597 45.50561797752809 M23.59550561797753 45.50561797752809 L26.966292134831463 45.50561797752809 M28.08988764044944 45.50561797752809 L29.213483146067418 45.50561797752809 M30.337078651685395 45.50561797752809 L34.831460674157306 45.50561797752809 M38.20224719101124 45.50561797752809 L41.57303370786517 45.50561797752809 M42.69662921348315 45.50561797752809 L44.943820224719104 45.50561797752809 M48.31460674157304 45.50561797752809 L49.438202247191015 45.50561797752809 M51.68539325842697 45.50561797752809 L55.0561797752809 45.50561797752809 M56.17977528089888 45.50561797752809 L57.30337078651686 45.50561797752809 M58.426966292134836 45.50561797752809 L59.55056179775281 45.50561797752809 M60.67415730337079 45.50561797752809 L61.79775280898877 45.50561797752809 M64.04494382022472 45.50561797752809 L66.29213483146069 45.50561797752809 M68.53932584269663 45.50561797752809 L69.66292134831461 45.50561797752809 M70.7865168539326 45.50561797752809 L75.2808988764045 45.50561797752809 M77.52808988764045 45.50561797752809 L78.65168539325843 45.50561797752809 M79.77528089887642 45.50561797752809 L82.02247191011236 45.50561797752809 M83.14606741573034 45.50561797752809 L86.51685393258427 45.50561797752809 M88.76404494382024 45.50561797752809 L91.01123595505618 45.50561797752809 M92.13483146067416 45.50561797752809 L95.50561797752809 45.50561797752809 M98.87640449438203 45.50561797752809 L100 45.50561797752809 M0 46.629213483146074 L2.247191011235955 46.629213483146074 M4.49438202247191 46.629213483146074 L5.617977528089888 46.629213483146074 M10.112359550561798 46.629213483146074 L14.606741573033709 46.629213483146074 M15.730337078651687 46.629213483146074 L16.853932584269664 46.629213483146074 M20.224719101123597 46.629213483146074 L22.471910112359552 46.629213483146074 M25.842696629213485 46.629213483146074 L30.337078651685395 46.629213483146074 M33.70786516853933 46.629213483146074 L34.831460674157306 46.629213483146074 M35.95505617977528 46.629213483146074 L38.20224719101124 46.629213483146074 M41.57303370786517 46.629213483146074 L42.69662921348315 46.629213483146074 M46.06741573033708 46.629213483146074 L48.31460674157304 46.629213483146074 M55.0561797752809 46.629213483146074 L56.17977528089888 46.629213483146074 M57.30337078651686 46.629213483146074 L60.67415730337079 46.629213483146074 M71.91011235955057 46.629213483146074 L73.03370786516854 46.629213483146074 M74.15730337078652 46.629213483146074 L75.2808988764045 46.629213483146074 M77.52808988764045 46.629213483146074 L80.89887640449439 46.629213483146074 M83.14606741573034 46.629213483146074 L85.3932584269663 46.629213483146074 M88.76404494382024 46.629213483146074 L89.88764044943821 46.629213483146074 M92.13483146067416 46.629213483146074 L93.25842696629215 46.629213483146074 M96.62921348314607 46.629213483146074 L100 46.629213483146074 M2.247191011235955 47.752808988764045 L4.49438202247191 47.752808988764045 M6.741573033707866 47.752808988764045 L8.98876404494382 47.752808988764045 M10.112359550561798 47.752808988764045 L13.483146067415731 47.752808988764045 M14.606741573033709 47.752808988764045 L15.730337078651687 47.752808988764045 M23.59550561797753 47.752808988764045 L24.719101123595507 47.752808988764045 M25.842696629213485 47.752808988764045 L31.460674157303373 47.752808988764045 M34.831460674157306 47.752808988764045 L39.325842696629216 47.752808988764045 M41.57303370786517 47.752808988764045 L42.69662921348315 47.752808988764045 M46.06741573033708 47.752808988764045 L47.19101123595506 47.752808988764045 M49.438202247191015 47.752808988764045 L50.56179775280899 47.752808988764045 M53.932584269662925 47.752808988764045 L55.0561797752809 47.752808988764045 M56.17977528089888 47.752808988764045 L57.30337078651686 47.752808988764045 M58.426966292134836 47.752808988764045 L60.67415730337079 47.752808988764045 M62.921348314606746 47.752808988764045 L65.1685393258427 47.752808988764045 M67.41573033707866 47.752808988764045 L69.66292134831461 47.752808988764045 M70.7865168539326 47.752808988764045 L71.91011235955057 47.752808988764045 M75.2808988764045 47.752808988764045 L83.14606741573034 47.752808988764045 M84.26966292134833 47.752808988764045 L85.3932584269663 47.752808988764045 M86.51685393258427 47.752808988764045 L87.64044943820225 47.752808988764045 M89.88764044943821 47.752808988764045 L91.01123595505618 47.752808988764045 M95.50561797752809 47.752808988764045 L96.62921348314607 47.752808988764045 M2.247191011235955 48.87640449438203 L6.741573033707866 48.87640449438203 M8.98876404494382 48.87640449438203 L11.235955056179776 48.87640449438203 M15.730337078651687 48.87640449438203 L20.224719101123597 48.87640449438203 M22.471910112359552 48.87640449438203 L23.59550561797753 48.87640449438203 M24.719101123595507 48.87640449438203 L26.966292134831463 48.87640449438203 M28.08988764044944 48.87640449438203 L30.337078651685395 48.87640449438203 M31.460674157303373 48.87640449438203 L33.70786516853933 48.87640449438203 M35.95505617977528 48.87640449438203 L37.07865168539326 48.87640449438203 M40.449438202247194 48.87640449438203 L41.57303370786517 48.87640449438203 M42.69662921348315 48.87640449438203 L47.19101123595506 48.87640449438203 M48.31460674157304 48.87640449438203 L49.438202247191015 48.87640449438203 M50.56179775280899 48.87640449438203 L51.68539325842697 48.87640449438203 M52.80898876404495 48.87640449438203 L56.17977528089888 48.87640449438203 M57.30337078651686 48.87640449438203 L58.426966292134836 48.87640449438203 M59.55056179775281 48.87640449438203 L60.67415730337079 48.87640449438203 M69.66292134831461 48.87640449438203 L70.7865168539326 48.87640449438203 M71.91011235955057 48.87640449438203 L73.03370786516854 48.87640449438203 M74.15730337078652 48.87640449438203 L76.40449438202248 48.87640449438203 M77.52808988764045 48.87640449438203 L79.77528089887642 48.87640449438203 M82.02247191011236 48.87640449438203 L84.26966292134833 48.87640449438203 M85.3932584269663 48.87640449438203 L87.64044943820225 48.87640449438203 M88.76404494382024 48.87640449438203 L89.88764044943821 48.87640449438203 M95.50561797752809 48.87640449438203 L96.62921348314607 48.87640449438203 M97.75280898876406 48.87640449438203 L100 48.87640449438203 M0 50 L2.247191011235955 50 M3.370786516853933 50 L7.865168539325843 50 M10.112359550561798 50 L11.235955056179776 50 M12.359550561797754 50 L13.483146067415731 50 M14.606741573033709 50 L16.853932584269664 50 M17.97752808988764 50 L22.471910112359552 50 M23.59550561797753 50 L25.842696629213485 50 M26.966292134831463 50 L28.08988764044944 50 M29.213483146067418 50 L32.58426966292135 50 M33.70786516853933 50 L37.07865168539326 50 M38.20224719101124 50 L41.57303370786517 50 M42.69662921348315 50 L43.82022471910113 50 M46.06741573033708 50 L49.438202247191015 50 M52.80898876404495 50 L55.0561797752809 50 M59.55056179775281 50 L66.29213483146069 50 M67.41573033707866 50 L69.66292134831461 50 M70.7865168539326 50 L71.91011235955057 50 M74.15730337078652 50 L75.2808988764045 50 M77.52808988764045 50 L79.77528089887642 50 M84.26966292134833 50 L88.76404494382024 50 M89.88764044943821 50 L92.13483146067416 50 M93.25842696629215 50 L95.50561797752809 50 M96.62921348314607 50 L98.87640449438203 50 M0 51.123595505617985 L1.1235955056179776 51.123595505617985 M3.370786516853933 51.123595505617985 L4.49438202247191 51.123595505617985 M5.617977528089888 51.123595505617985 L6.741573033707866 51.123595505617985 M8.98876404494382 51.123595505617985 L11.235955056179776 51.123595505617985 M12.359550561797754 51.123595505617985 L17.97752808988764 51.123595505617985 M19.10112359550562 51.123595505617985 L22.471910112359552 51.123595505617985 M25.842696629213485 51.123595505617985 L28.08988764044944 51.123595505617985 M29.213483146067418 51.123595505617985 L31.460674157303373 51.123595505617985 M32.58426966292135 51.123595505617985 L42.69662921348315 51.123595505617985 M46.06741573033708 51.123595505617985 L48.31460674157304 51.123595505617985 M49.438202247191015 51.123595505617985 L51.68539325842697 51.123595505617985 M52.80898876404495 51.123595505617985 L56.17977528089888 51.123595505617985 M57.30337078651686 51.123595505617985 L58.426966292134836 51.123595505617985 M66.29213483146069 51.123595505617985 L68.53932584269663 51.123595505617985 M69.66292134831461 51.123595505617985 L71.91011235955057 51.123595505617985 M76.40449438202248 51.123595505617985 L78.65168539325843 51.123595505617985 M85.3932584269663 51.123595505617985 L86.51685393258427 51.123595505617985 M87.64044943820225 51.123595505617985 L88.76404494382024 51.123595505617985 M92.13483146067416 51.123595505617985 L93.25842696629215 51.123595505617985 M95.50561797752809 51.123595505617985 L98.87640449438203 51.123595505617985 M1.1235955056179776 52.247191011235955 L4.49438202247191 52.247191011235955 M6.741573033707866 52.247191011235955 L10.112359550561798 52.247191011235955 M11.235955056179776 52.247191011235955 L12.359550561797754 52.247191011235955 M13.483146067415731 52.247191011235955 L17.97752808988764 52.247191011235955 M23.59550561797753 52.247191011235955 L24.719101123595507 52.247191011235955 M25.842696629213485 52.247191011235955 L26.966292134831463 52.247191011235955 M28.08988764044944 52.247191011235955 L30.337078651685395 52.247191011235955 M31.460674157303373 52.247191011235955 L32.58426966292135 52.247191011235955 M34.831460674157306 52.247191011235955 L35.95505617977528 52.247191011235955 M38.20224719101124 52.247191011235955 L39.325842696629216 52.247191011235955 M46.06741573033708 52.247191011235955 L47.19101123595506 52.247191011235955 M52.80898876404495 52.247191011235955 L53.932584269662925 52.247191011235955 M55.0561797752809 52.247191011235955 L56.17977528089888 52.247191011235955 M59.55056179775281 52.247191011235955 L61.79775280898877 52.247191011235955 M62.921348314606746 52.247191011235955 L65.1685393258427 52.247191011235955 M67.41573033707866 52.247191011235955 L68.53932584269663 52.247191011235955 M69.66292134831461 52.247191011235955 L71.91011235955057 52.247191011235955 M74.15730337078652 52.247191011235955 L80.89887640449439 52.247191011235955 M83.14606741573034 52.247191011235955 L84.26966292134833 52.247191011235955 M85.3932584269663 52.247191011235955 L87.64044943820225 52.247191011235955 M88.76404494382024 52.247191011235955 L89.88764044943821 52.247191011235955 M91.01123595505618 52.247191011235955 L94.38202247191012 52.247191011235955 M1.1235955056179776 53.37078651685394 L3.370786516853933 53.37078651685394 M5.617977528089888 53.37078651685394 L6.741573033707866 53.37078651685394 M7.865168539325843 53.37078651685394 L12.359550561797754 53.37078651685394 M13.483146067415731 53.37078651685394 L14.606741573033709 53.37078651685394 M15.730337078651687 53.37078651685394 L16.853932584269664 53.37078651685394 M17.97752808988764 53.37078651685394 L20.224719101123597 53.37078651685394 M23.59550561797753 53.37078651685394 L25.842696629213485 53.37078651685394 M26.966292134831463 53.37078651685394 L30.337078651685395 53.37078651685394 M33.70786516853933 53.37078651685394 L38.20224719101124 53.37078651685394 M42.69662921348315 53.37078651685394 L44.943820224719104 53.37078651685394 M46.06741573033708 53.37078651685394 L51.68539325842697 53.37078651685394 M52.80898876404495 53.37078651685394 L53.932584269662925 53.37078651685394 M55.0561797752809 53.37078651685394 L56.17977528089888 53.37078651685394 M59.55056179775281 53.37078651685394 L61.79775280898877 53.37078651685394 M62.921348314606746 53.37078651685394 L66.29213483146069 53.37078651685394 M68.53932584269663 53.37078651685394 L69.66292134831461 53.37078651685394 M70.7865168539326 53.37078651685394 L74.15730337078652 53.37078651685394 M75.2808988764045 53.37078651685394 L77.52808988764045 53.37078651685394 M79.77528089887642 53.37078651685394 L83.14606741573034 53.37078651685394 M84.26966292134833 53.37078651685394 L89.88764044943821 53.37078651685394 M92.13483146067416 53.37078651685394 L93.25842696629215 53.37078651685394 M94.38202247191012 53.37078651685394 L96.62921348314607 53.37078651685394 M97.75280898876406 53.37078651685394 L100 53.37078651685394 M1.1235955056179776 54.49438202247191 L2.247191011235955 54.49438202247191 M4.49438202247191 54.49438202247191 L5.617977528089888 54.49438202247191 M6.741573033707866 54.49438202247191 L7.865168539325843 54.49438202247191 M8.98876404494382 54.49438202247191 L12.359550561797754 54.49438202247191 M14.606741573033709 54.49438202247191 L16.853932584269664 54.49438202247191 M20.224719101123597 54.49438202247191 L21.348314606741575 54.49438202247191 M22.471910112359552 54.49438202247191 L23.59550561797753 54.49438202247191 M24.719101123595507 54.49438202247191 L25.842696629213485 54.49438202247191 M30.337078651685395 54.49438202247191 L33.70786516853933 54.49438202247191 M34.831460674157306 54.49438202247191 L38.20224719101124 54.49438202247191 M39.325842696629216 54.49438202247191 L42.69662921348315 54.49438202247191 M44.943820224719104 54.49438202247191 L46.06741573033708 54.49438202247191 M47.19101123595506 54.49438202247191 L49.438202247191015 54.49438202247191 M52.80898876404495 54.49438202247191 L57.30337078651686 54.49438202247191 M59.55056179775281 54.49438202247191 L62.921348314606746 54.49438202247191 M66.29213483146069 54.49438202247191 L68.53932584269663 54.49438202247191 M70.7865168539326 54.49438202247191 L71.91011235955057 54.49438202247191 M74.15730337078652 54.49438202247191 L75.2808988764045 54.49438202247191 M77.52808988764045 54.49438202247191 L78.65168539325843 54.49438202247191 M83.14606741573034 54.49438202247191 L85.3932584269663 54.49438202247191 M87.64044943820225 54.49438202247191 L88.76404494382024 54.49438202247191 M91.01123595505618 54.49438202247191 L92.13483146067416 54.49438202247191 M93.25842696629215 54.49438202247191 L95.50561797752809 54.49438202247191 M96.62921348314607 54.49438202247191 L97.75280898876406 54.49438202247191 M98.87640449438203 54.49438202247191 L100 54.49438202247191 M0 55.617977528089895 L2.247191011235955 55.617977528089895 M3.370786516853933 55.617977528089895 L6.741573033707866 55.617977528089895 M13.483146067415731 55.617977528089895 L14.606741573033709 55.617977528089895 M15.730337078651687 55.617977528089895 L17.97752808988764 55.617977528089895 M19.10112359550562 55.617977528089895 L21.348314606741575 55.617977528089895 M22.471910112359552 55.617977528089895 L23.59550561797753 55.617977528089895 M26.966292134831463 55.617977528089895 L29.213483146067418 55.617977528089895 M34.831460674157306 55.617977528089895 L37.07865168539326 55.617977528089895 M38.20224719101124 55.617977528089895 L41.57303370786517 55.617977528089895 M43.82022471910113 55.617977528089895 L49.438202247191015 55.617977528089895 M53.932584269662925 55.617977528089895 L55.0561797752809 55.617977528089895 M62.921348314606746 55.617977528089895 L65.1685393258427 55.617977528089895 M66.29213483146069 55.617977528089895 L67.41573033707866 55.617977528089895 M69.66292134831461 55.617977528089895 L70.7865168539326 55.617977528089895 M71.91011235955057 55.617977528089895 L73.03370786516854 55.617977528089895 M77.52808988764045 55.617977528089895 L78.65168539325843 55.617977528089895 M91.01123595505618 55.617977528089895 L93.25842696629215 55.617977528089895 M95.50561797752809 55.617977528089895 L97.75280898876406 55.617977528089895 M0 56.741573033707866 L2.247191011235955 56.741573033707866 M6.741573033707866 56.741573033707866 L7.865168539325843 56.741573033707866 M8.98876404494382 56.741573033707866 L11.235955056179776 56.741573033707866 M12.359550561797754 56.741573033707866 L14.606741573033709 56.741573033707866 M15.730337078651687 56.741573033707866 L17.97752808988764 56.741573033707866 M19.10112359550562 56.741573033707866 L21.348314606741575 56.741573033707866 M25.842696629213485 56.741573033707866 L26.966292134831463 56.741573033707866 M28.08988764044944 56.741573033707866 L31.460674157303373 56.741573033707866 M32.58426966292135 56.741573033707866 L33.70786516853933 56.741573033707866 M35.95505617977528 56.741573033707866 L37.07865168539326 56.741573033707866 M40.449438202247194 56.741573033707866 L41.57303370786517 56.741573033707866 M42.69662921348315 56.741573033707866 L43.82022471910113 56.741573033707866 M44.943820224719104 56.741573033707866 L51.68539325842697 56.741573033707866 M55.0561797752809 56.741573033707866 L57.30337078651686 56.741573033707866 M58.426966292134836 56.741573033707866 L61.79775280898877 56.741573033707866 M62.921348314606746 56.741573033707866 L67.41573033707866 56.741573033707866 M69.66292134831461 56.741573033707866 L70.7865168539326 56.741573033707866 M75.2808988764045 56.741573033707866 L76.40449438202248 56.741573033707866 M78.65168539325843 56.741573033707866 L79.77528089887642 56.741573033707866 M82.02247191011236 56.741573033707866 L83.14606741573034 56.741573033707866 M85.3932584269663 56.741573033707866 L86.51685393258427 56.741573033707866 M89.88764044943821 56.741573033707866 L95.50561797752809 56.741573033707866 M96.62921348314607 56.741573033707866 L97.75280898876406 56.741573033707866 M0 57.86516853932585 L1.1235955056179776 57.86516853932585 M2.247191011235955 57.86516853932585 L3.370786516853933 57.86516853932585 M4.49438202247191 57.86516853932585 L5.617977528089888 57.86516853932585 M10.112359550561798 57.86516853932585 L16.853932584269664 57.86516853932585 M24.719101123595507 57.86516853932585 L25.842696629213485 57.86516853932585 M26.966292134831463 57.86516853932585 L28.08988764044944 57.86516853932585 M31.460674157303373 57.86516853932585 L33.70786516853933 57.86516853932585 M35.95505617977528 57.86516853932585 L38.20224719101124 57.86516853932585 M39.325842696629216 57.86516853932585 L41.57303370786517 57.86516853932585 M44.943820224719104 57.86516853932585 L46.06741573033708 57.86516853932585 M48.31460674157304 57.86516853932585 L49.438202247191015 57.86516853932585 M50.56179775280899 57.86516853932585 L52.80898876404495 57.86516853932585 M53.932584269662925 57.86516853932585 L56.17977528089888 57.86516853932585 M65.1685393258427 57.86516853932585 L66.29213483146069 57.86516853932585 M70.7865168539326 57.86516853932585 L75.2808988764045 57.86516853932585 M76.40449438202248 57.86516853932585 L79.77528089887642 57.86516853932585 M83.14606741573034 57.86516853932585 L86.51685393258427 57.86516853932585 M87.64044943820225 57.86516853932585 L89.88764044943821 57.86516853932585 M91.01123595505618 57.86516853932585 L92.13483146067416 57.86516853932585 M93.25842696629215 57.86516853932585 L94.38202247191012 57.86516853932585 M95.50561797752809 57.86516853932585 L96.62921348314607 57.86516853932585 M97.75280898876406 57.86516853932585 L98.87640449438203 57.86516853932585 M0 58.98876404494382 L1.1235955056179776 58.98876404494382 M2.247191011235955 58.98876404494382 L5.617977528089888 58.98876404494382 M6.741573033707866 58.98876404494382 L7.865168539325843 58.98876404494382 M8.98876404494382 58.98876404494382 L10.112359550561798 58.98876404494382 M13.483146067415731 58.98876404494382 L14.606741573033709 58.98876404494382 M22.471910112359552 58.98876404494382 L24.719101123595507 58.98876404494382 M25.842696629213485 58.98876404494382 L26.966292134831463 58.98876404494382 M28.08988764044944 58.98876404494382 L29.213483146067418 58.98876404494382 M30.337078651685395 58.98876404494382 L33.70786516853933 58.98876404494382 M35.95505617977528 58.98876404494382 L38.20224719101124 58.98876404494382 M39.325842696629216 58.98876404494382 L44.943820224719104 58.98876404494382 M48.31460674157304 58.98876404494382 L49.438202247191015 58.98876404494382 M51.68539325842697 58.98876404494382 L57.30337078651686 58.98876404494382 M59.55056179775281 58.98876404494382 L65.1685393258427 58.98876404494382 M67.41573033707866 58.98876404494382 L68.53932584269663 58.98876404494382 M69.66292134831461 58.98876404494382 L75.2808988764045 58.98876404494382 M76.40449438202248 58.98876404494382 L79.77528089887642 58.98876404494382 M80.89887640449439 58.98876404494382 L82.02247191011236 58.98876404494382 M84.26966292134833 58.98876404494382 L85.3932584269663 58.98876404494382 M87.64044943820225 58.98876404494382 L89.88764044943821 58.98876404494382 M92.13483146067416 58.98876404494382 L100 58.98876404494382 M0 60.112359550561806 L1.1235955056179776 60.112359550561806 M5.617977528089888 60.112359550561806 L6.741573033707866 60.112359550561806 M7.865168539325843 60.112359550561806 L8.98876404494382 60.112359550561806 M11.235955056179776 60.112359550561806 L13.483146067415731 60.112359550561806 M14.606741573033709 60.112359550561806 L16.853932584269664 60.112359550561806 M20.224719101123597 60.112359550561806 L23.59550561797753 60.112359550561806 M24.719101123595507 60.112359550561806 L28.08988764044944 60.112359550561806 M30.337078651685395 60.112359550561806 L31.460674157303373 60.112359550561806 M32.58426966292135 60.112359550561806 L34.831460674157306 60.112359550561806 M39.325842696629216 60.112359550561806 L40.449438202247194 60.112359550561806 M41.57303370786517 60.112359550561806 L42.69662921348315 60.112359550561806 M44.943820224719104 60.112359550561806 L48.31460674157304 60.112359550561806 M52.80898876404495 60.112359550561806 L53.932584269662925 60.112359550561806 M55.0561797752809 60.112359550561806 L56.17977528089888 60.112359550561806 M57.30337078651686 60.112359550561806 L60.67415730337079 60.112359550561806 M61.79775280898877 60.112359550561806 L62.921348314606746 60.112359550561806 M64.04494382022472 60.112359550561806 L65.1685393258427 60.112359550561806 M66.29213483146069 60.112359550561806 L68.53932584269663 60.112359550561806 M69.66292134831461 60.112359550561806 L70.7865168539326 60.112359550561806 M71.91011235955057 60.112359550561806 L73.03370786516854 60.112359550561806 M74.15730337078652 60.112359550561806 L75.2808988764045 60.112359550561806 M77.52808988764045 60.112359550561806 L78.65168539325843 60.112359550561806 M80.89887640449439 60.112359550561806 L82.02247191011236 60.112359550561806 M85.3932584269663 60.112359550561806 L86.51685393258427 60.112359550561806 M89.88764044943821 60.112359550561806 L97.75280898876406 60.112359550561806 M98.87640449438203 60.112359550561806 L100 60.112359550561806 M2.247191011235955 61.235955056179776 L3.370786516853933 61.235955056179776 M4.49438202247191 61.235955056179776 L10.112359550561798 61.235955056179776 M11.235955056179776 61.235955056179776 L12.359550561797754 61.235955056179776 M14.606741573033709 61.235955056179776 L16.853932584269664 61.235955056179776 M19.10112359550562 61.235955056179776 L20.224719101123597 61.235955056179776 M21.348314606741575 61.235955056179776 L22.471910112359552 61.235955056179776 M23.59550561797753 61.235955056179776 L24.719101123595507 61.235955056179776 M25.842696629213485 61.235955056179776 L26.966292134831463 61.235955056179776 M29.213483146067418 61.235955056179776 L39.325842696629216 61.235955056179776 M40.449438202247194 61.235955056179776 L41.57303370786517 61.235955056179776 M42.69662921348315 61.235955056179776 L49.438202247191015 61.235955056179776 M50.56179775280899 61.235955056179776 L51.68539325842697 61.235955056179776 M52.80898876404495 61.235955056179776 L55.0561797752809 61.235955056179776 M57.30337078651686 61.235955056179776 L59.55056179775281 61.235955056179776 M60.67415730337079 61.235955056179776 L66.29213483146069 61.235955056179776 M69.66292134831461 61.235955056179776 L73.03370786516854 61.235955056179776 M75.2808988764045 61.235955056179776 L79.77528089887642 61.235955056179776 M80.89887640449439 61.235955056179776 L82.02247191011236 61.235955056179776 M83.14606741573034 61.235955056179776 L84.26966292134833 61.235955056179776 M85.3932584269663 61.235955056179776 L86.51685393258427 61.235955056179776 M87.64044943820225 61.235955056179776 L95.50561797752809 61.235955056179776 M96.62921348314607 61.235955056179776 L97.75280898876406 61.235955056179776 M1.1235955056179776 62.35955056179776 L2.247191011235955 62.35955056179776 M3.370786516853933 62.35955056179776 L5.617977528089888 62.35955056179776 M8.98876404494382 62.35955056179776 L10.112359550561798 62.35955056179776 M12.359550561797754 62.35955056179776 L15.730337078651687 62.35955056179776 M17.97752808988764 62.35955056179776 L21.348314606741575 62.35955056179776 M22.471910112359552 62.35955056179776 L23.59550561797753 62.35955056179776 M24.719101123595507 62.35955056179776 L28.08988764044944 62.35955056179776 M29.213483146067418 62.35955056179776 L30.337078651685395 62.35955056179776 M31.460674157303373 62.35955056179776 L32.58426966292135 62.35955056179776 M35.95505617977528 62.35955056179776 L37.07865168539326 62.35955056179776 M39.325842696629216 62.35955056179776 L43.82022471910113 62.35955056179776 M44.943820224719104 62.35955056179776 L46.06741573033708 62.35955056179776 M48.31460674157304 62.35955056179776 L50.56179775280899 62.35955056179776 M51.68539325842697 62.35955056179776 L52.80898876404495 62.35955056179776 M53.932584269662925 62.35955056179776 L58.426966292134836 62.35955056179776 M59.55056179775281 62.35955056179776 L61.79775280898877 62.35955056179776 M65.1685393258427 62.35955056179776 L66.29213483146069 62.35955056179776 M71.91011235955057 62.35955056179776 L73.03370786516854 62.35955056179776 M74.15730337078652 62.35955056179776 L75.2808988764045 62.35955056179776 M76.40449438202248 62.35955056179776 L77.52808988764045 62.35955056179776 M82.02247191011236 62.35955056179776 L84.26966292134833 62.35955056179776 M85.3932584269663 62.35955056179776 L87.64044943820225 62.35955056179776 M89.88764044943821 62.35955056179776 L91.01123595505618 62.35955056179776 M94.38202247191012 62.35955056179776 L96.62921348314607 62.35955056179776 M98.87640449438203 62.35955056179776 L100 62.35955056179776 M0 63.48314606741573 L1.1235955056179776 63.48314606741573 M4.49438202247191 63.48314606741573 L5.617977528089888 63.48314606741573 M6.741573033707866 63.48314606741573 L7.865168539325843 63.48314606741573 M8.98876404494382 63.48314606741573 L14.606741573033709 63.48314606741573 M15.730337078651687 63.48314606741573 L16.853932584269664 63.48314606741573 M19.10112359550562 63.48314606741573 L20.224719101123597 63.48314606741573 M21.348314606741575 63.48314606741573 L25.842696629213485 63.48314606741573 M29.213483146067418 63.48314606741573 L32.58426966292135 63.48314606741573 M33.70786516853933 63.48314606741573 L34.831460674157306 63.48314606741573 M35.95505617977528 63.48314606741573 L38.20224719101124 63.48314606741573 M39.325842696629216 63.48314606741573 L41.57303370786517 63.48314606741573 M42.69662921348315 63.48314606741573 L43.82022471910113 63.48314606741573 M46.06741573033708 63.48314606741573 L49.438202247191015 63.48314606741573 M52.80898876404495 63.48314606741573 L57.30337078651686 63.48314606741573 M60.67415730337079 63.48314606741573 L61.79775280898877 63.48314606741573 M62.921348314606746 63.48314606741573 L64.04494382022472 63.48314606741573 M65.1685393258427 63.48314606741573 L66.29213483146069 63.48314606741573 M67.41573033707866 63.48314606741573 L71.91011235955057 63.48314606741573 M76.40449438202248 63.48314606741573 L77.52808988764045 63.48314606741573 M78.65168539325843 63.48314606741573 L79.77528089887642 63.48314606741573 M80.89887640449439 63.48314606741573 L85.3932584269663 63.48314606741573 M87.64044943820225 63.48314606741573 L91.01123595505618 63.48314606741573 M92.13483146067416 63.48314606741573 L93.25842696629215 63.48314606741573 M94.38202247191012 63.48314606741573 L98.87640449438203 63.48314606741573 M3.370786516853933 64.6067415730337 L5.617977528089888 64.6067415730337 M8.98876404494382 64.6067415730337 L12.359550561797754 64.6067415730337 M13.483146067415731 64.6067415730337 L14.606741573033709 64.6067415730337 M15.730337078651687 64.6067415730337 L16.853932584269664 64.6067415730337 M20.224719101123597 64.6067415730337 L21.348314606741575 64.6067415730337 M22.471910112359552 64.6067415730337 L24.719101123595507 64.6067415730337 M25.842696629213485 64.6067415730337 L32.58426966292135 64.6067415730337 M35.95505617977528 64.6067415730337 L39.325842696629216 64.6067415730337 M41.57303370786517 64.6067415730337 L44.943820224719104 64.6067415730337 M46.06741573033708 64.6067415730337 L48.31460674157304 64.6067415730337 M49.438202247191015 64.6067415730337 L50.56179775280899 64.6067415730337 M55.0561797752809 64.6067415730337 L56.17977528089888 64.6067415730337 M60.67415730337079 64.6067415730337 L61.79775280898877 64.6067415730337 M65.1685393258427 64.6067415730337 L67.41573033707866 64.6067415730337 M70.7865168539326 64.6067415730337 L71.91011235955057 64.6067415730337 M74.15730337078652 64.6067415730337 L75.2808988764045 64.6067415730337 M77.52808988764045 64.6067415730337 L79.77528089887642 64.6067415730337 M84.26966292134833 64.6067415730337 L85.3932584269663 64.6067415730337 M87.64044943820225 64.6067415730337 L88.76404494382024 64.6067415730337 M89.88764044943821 64.6067415730337 L91.01123595505618 64.6067415730337 M94.38202247191012 64.6067415730337 L95.50561797752809 64.6067415730337 M3.370786516853933 65.73033707865169 L12.359550561797754 65.73033707865169 M15.730337078651687 65.73033707865169 L19.10112359550562 65.73033707865169 M20.224719101123597 65.73033707865169 L22.471910112359552 65.73033707865169 M24.719101123595507 65.73033707865169 L25.842696629213485 65.73033707865169 M26.966292134831463 65.73033707865169 L28.08988764044944 65.73033707865169 M29.213483146067418 65.73033707865169 L37.07865168539326 65.73033707865169 M46.06741573033708 65.73033707865169 L47.19101123595506 65.73033707865169 M49.438202247191015 65.73033707865169 L51.68539325842697 65.73033707865169 M58.426966292134836 65.73033707865169 L59.55056179775281 65.73033707865169 M60.67415730337079 65.73033707865169 L66.29213483146069 65.73033707865169 M68.53932584269663 65.73033707865169 L70.7865168539326 65.73033707865169 M71.91011235955057 65.73033707865169 L75.2808988764045 65.73033707865169 M76.40449438202248 65.73033707865169 L77.52808988764045 65.73033707865169 M78.65168539325843 65.73033707865169 L79.77528089887642 65.73033707865169 M82.02247191011236 65.73033707865169 L84.26966292134833 65.73033707865169 M89.88764044943821 65.73033707865169 L96.62921348314607 65.73033707865169 M0 66.85393258426967 L1.1235955056179776 66.85393258426967 M2.247191011235955 66.85393258426967 L3.370786516853933 66.85393258426967 M7.865168539325843 66.85393258426967 L8.98876404494382 66.85393258426967 M10.112359550561798 66.85393258426967 L11.235955056179776 66.85393258426967 M13.483146067415731 66.85393258426967 L15.730337078651687 66.85393258426967 M16.853932584269664 66.85393258426967 L19.10112359550562 66.85393258426967 M21.348314606741575 66.85393258426967 L22.471910112359552 66.85393258426967 M24.719101123595507 66.85393258426967 L25.842696629213485 66.85393258426967 M30.337078651685395 66.85393258426967 L31.460674157303373 66.85393258426967 M34.831460674157306 66.85393258426967 L39.325842696629216 66.85393258426967 M42.69662921348315 66.85393258426967 L43.82022471910113 66.85393258426967 M46.06741573033708 66.85393258426967 L49.438202247191015 66.85393258426967 M50.56179775280899 66.85393258426967 L55.0561797752809 66.85393258426967 M61.79775280898877 66.85393258426967 L65.1685393258427 66.85393258426967 M68.53932584269663 66.85393258426967 L69.66292134831461 66.85393258426967 M70.7865168539326 66.85393258426967 L73.03370786516854 66.85393258426967 M78.65168539325843 66.85393258426967 L79.77528089887642 66.85393258426967 M82.02247191011236 66.85393258426967 L84.26966292134833 66.85393258426967 M85.3932584269663 66.85393258426967 L88.76404494382024 66.85393258426967 M93.25842696629215 66.85393258426967 L94.38202247191012 66.85393258426967 M95.50561797752809 66.85393258426967 L96.62921348314607 66.85393258426967 M97.75280898876406 66.85393258426967 L100 66.85393258426967 M0 67.97752808988764 L1.1235955056179776 67.97752808988764 M2.247191011235955 67.97752808988764 L3.370786516853933 67.97752808988764 M6.741573033707866 67.97752808988764 L7.865168539325843 67.97752808988764 M8.98876404494382 67.97752808988764 L10.112359550561798 67.97752808988764 M11.235955056179776 67.97752808988764 L13.483146067415731 67.97752808988764 M19.10112359550562 67.97752808988764 L20.224719101123597 67.97752808988764 M21.348314606741575 67.97752808988764 L22.471910112359552 67.97752808988764 M24.719101123595507 67.97752808988764 L25.842696629213485 67.97752808988764 M26.966292134831463 67.97752808988764 L29.213483146067418 67.97752808988764 M33.70786516853933 67.97752808988764 L34.831460674157306 67.97752808988764 M35.95505617977528 67.97752808988764 L38.20224719101124 67.97752808988764 M39.325842696629216 67.97752808988764 L41.57303370786517 67.97752808988764 M42.69662921348315 67.97752808988764 L43.82022471910113 67.97752808988764 M47.19101123595506 67.97752808988764 L49.438202247191015 67.97752808988764 M53.932584269662925 67.97752808988764 L57.30337078651686 67.97752808988764 M59.55056179775281 67.97752808988764 L61.79775280898877 67.97752808988764 M64.04494382022472 67.97752808988764 L66.29213483146069 67.97752808988764 M69.66292134831461 67.97752808988764 L75.2808988764045 67.97752808988764 M76.40449438202248 67.97752808988764 L77.52808988764045 67.97752808988764 M80.89887640449439 67.97752808988764 L83.14606741573034 67.97752808988764 M84.26966292134833 67.97752808988764 L85.3932584269663 67.97752808988764 M87.64044943820225 67.97752808988764 L89.88764044943821 67.97752808988764 M93.25842696629215 67.97752808988764 L96.62921348314607 67.97752808988764 M97.75280898876406 67.97752808988764 L100 67.97752808988764 M0 69.10112359550561 L2.247191011235955 69.10112359550561 M8.98876404494382 69.10112359550561 L10.112359550561798 69.10112359550561 M11.235955056179776 69.10112359550561 L12.359550561797754 69.10112359550561 M13.483146067415731 69.10112359550561 L14.606741573033709 69.10112359550561 M15.730337078651687 69.10112359550561 L17.97752808988764 69.10112359550561 M20.224719101123597 69.10112359550561 L22.471910112359552 69.10112359550561 M24.719101123595507 69.10112359550561 L25.842696629213485 69.10112359550561 M26.966292134831463 69.10112359550561 L28.08988764044944 69.10112359550561 M30.337078651685395 69.10112359550561 L31.460674157303373 69.10112359550561 M34.831460674157306 69.10112359550561 L38.20224719101124 69.10112359550561 M40.449438202247194 69.10112359550561 L41.57303370786517 69.10112359550561 M43.82022471910113 69.10112359550561 L44.943820224719104 69.10112359550561 M46.06741573033708 69.10112359550561 L49.438202247191015 69.10112359550561 M52.80898876404495 69.10112359550561 L56.17977528089888 69.10112359550561 M59.55056179775281 69.10112359550561 L60.67415730337079 69.10112359550561 M61.79775280898877 69.10112359550561 L65.1685393258427 69.10112359550561 M69.66292134831461 69.10112359550561 L71.91011235955057 69.10112359550561 M77.52808988764045 69.10112359550561 L78.65168539325843 69.10112359550561 M79.77528089887642 69.10112359550561 L82.02247191011236 69.10112359550561 M84.26966292134833 69.10112359550561 L85.3932584269663 69.10112359550561 M88.76404494382024 69.10112359550561 L91.01123595505618 69.10112359550561 M93.25842696629215 69.10112359550561 L95.50561797752809 69.10112359550561 M96.62921348314607 69.10112359550561 L100 69.10112359550561 M0 70.2247191011236 L1.1235955056179776 70.2247191011236 M2.247191011235955 70.2247191011236 L4.49438202247191 70.2247191011236 M5.617977528089888 70.2247191011236 L7.865168539325843 70.2247191011236 M8.98876404494382 70.2247191011236 L10.112359550561798 70.2247191011236 M21.348314606741575 70.2247191011236 L23.59550561797753 70.2247191011236 M25.842696629213485 70.2247191011236 L26.966292134831463 70.2247191011236 M29.213483146067418 70.2247191011236 L30.337078651685395 70.2247191011236 M33.70786516853933 70.2247191011236 L34.831460674157306 70.2247191011236 M35.95505617977528 70.2247191011236 L39.325842696629216 70.2247191011236 M41.57303370786517 70.2247191011236 L43.82022471910113 70.2247191011236 M50.56179775280899 70.2247191011236 L52.80898876404495 70.2247191011236 M53.932584269662925 70.2247191011236 L55.0561797752809 70.2247191011236 M58.426966292134836 70.2247191011236 L59.55056179775281 70.2247191011236 M60.67415730337079 70.2247191011236 L62.921348314606746 70.2247191011236 M64.04494382022472 70.2247191011236 L65.1685393258427 70.2247191011236 M66.29213483146069 70.2247191011236 L70.7865168539326 70.2247191011236 M77.52808988764045 70.2247191011236 L80.89887640449439 70.2247191011236 M82.02247191011236 70.2247191011236 L85.3932584269663 70.2247191011236 M91.01123595505618 70.2247191011236 L92.13483146067416 70.2247191011236 M93.25842696629215 70.2247191011236 L94.38202247191012 70.2247191011236 M0 71.34831460674158 L2.247191011235955 71.34831460674158 M3.370786516853933 71.34831460674158 L5.617977528089888 71.34831460674158 M11.235955056179776 71.34831460674158 L13.483146067415731 71.34831460674158 M14.606741573033709 71.34831460674158 L15.730337078651687 71.34831460674158 M19.10112359550562 71.34831460674158 L25.842696629213485 71.34831460674158 M26.966292134831463 71.34831460674158 L29.213483146067418 71.34831460674158 M30.337078651685395 71.34831460674158 L31.460674157303373 71.34831460674158 M32.58426966292135 71.34831460674158 L33.70786516853933 71.34831460674158 M34.831460674157306 71.34831460674158 L37.07865168539326 71.34831460674158 M38.20224719101124 71.34831460674158 L39.325842696629216 71.34831460674158 M42.69662921348315 71.34831460674158 L43.82022471910113 71.34831460674158 M44.943820224719104 71.34831460674158 L47.19101123595506 71.34831460674158 M48.31460674157304 71.34831460674158 L49.438202247191015 71.34831460674158 M51.68539325842697 71.34831460674158 L52.80898876404495 71.34831460674158 M53.932584269662925 71.34831460674158 L60.67415730337079 71.34831460674158 M61.79775280898877 71.34831460674158 L67.41573033707866 71.34831460674158 M68.53932584269663 71.34831460674158 L70.7865168539326 71.34831460674158 M71.91011235955057 71.34831460674158 L73.03370786516854 71.34831460674158 M74.15730337078652 71.34831460674158 L75.2808988764045 71.34831460674158 M76.40449438202248 71.34831460674158 L77.52808988764045 71.34831460674158 M79.77528089887642 71.34831460674158 L80.89887640449439 71.34831460674158 M82.02247191011236 71.34831460674158 L84.26966292134833 71.34831460674158 M85.3932584269663 71.34831460674158 L88.76404494382024 71.34831460674158 M91.01123595505618 71.34831460674158 L96.62921348314607 71.34831460674158 M97.75280898876406 71.34831460674158 L100 71.34831460674158 M1.1235955056179776 72.47191011235955 L2.247191011235955 72.47191011235955 M3.370786516853933 72.47191011235955 L5.617977528089888 72.47191011235955 M6.741573033707866 72.47191011235955 L10.112359550561798 72.47191011235955 M11.235955056179776 72.47191011235955 L13.483146067415731 72.47191011235955 M14.606741573033709 72.47191011235955 L15.730337078651687 72.47191011235955 M17.97752808988764 72.47191011235955 L25.842696629213485 72.47191011235955 M30.337078651685395 72.47191011235955 L31.460674157303373 72.47191011235955 M34.831460674157306 72.47191011235955 L35.95505617977528 72.47191011235955 M37.07865168539326 72.47191011235955 L38.20224719101124 72.47191011235955 M40.449438202247194 72.47191011235955 L41.57303370786517 72.47191011235955 M42.69662921348315 72.47191011235955 L44.943820224719104 72.47191011235955 M46.06741573033708 72.47191011235955 L47.19101123595506 72.47191011235955 M48.31460674157304 72.47191011235955 L49.438202247191015 72.47191011235955 M50.56179775280899 72.47191011235955 L55.0561797752809 72.47191011235955 M56.17977528089888 72.47191011235955 L57.30337078651686 72.47191011235955 M60.67415730337079 72.47191011235955 L61.79775280898877 72.47191011235955 M64.04494382022472 72.47191011235955 L66.29213483146069 72.47191011235955 M67.41573033707866 72.47191011235955 L68.53932584269663 72.47191011235955 M69.66292134831461 72.47191011235955 L74.15730337078652 72.47191011235955 M76.40449438202248 72.47191011235955 L77.52808988764045 72.47191011235955 M78.65168539325843 72.47191011235955 L79.77528089887642 72.47191011235955 M80.89887640449439 72.47191011235955 L83.14606741573034 72.47191011235955 M84.26966292134833 72.47191011235955 L86.51685393258427 72.47191011235955 M87.64044943820225 72.47191011235955 L88.76404494382024 72.47191011235955 M89.88764044943821 72.47191011235955 L91.01123595505618 72.47191011235955 M97.75280898876406 72.47191011235955 L100 72.47191011235955 M2.247191011235955 73.59550561797752 L3.370786516853933 73.59550561797752 M7.865168539325843 73.59550561797752 L8.98876404494382 73.59550561797752 M10.112359550561798 73.59550561797752 L16.853932584269664 73.59550561797752 M17.97752808988764 73.59550561797752 L21.348314606741575 73.59550561797752 M24.719101123595507 73.59550561797752 L25.842696629213485 73.59550561797752 M28.08988764044944 73.59550561797752 L34.831460674157306 73.59550561797752 M35.95505617977528 73.59550561797752 L38.20224719101124 73.59550561797752 M39.325842696629216 73.59550561797752 L42.69662921348315 73.59550561797752 M44.943820224719104 73.59550561797752 L49.438202247191015 73.59550561797752 M50.56179775280899 73.59550561797752 L51.68539325842697 73.59550561797752 M53.932584269662925 73.59550561797752 L60.67415730337079 73.59550561797752 M61.79775280898877 73.59550561797752 L64.04494382022472 73.59550561797752 M69.66292134831461 73.59550561797752 L71.91011235955057 73.59550561797752 M75.2808988764045 73.59550561797752 L76.40449438202248 73.59550561797752 M80.89887640449439 73.59550561797752 L82.02247191011236 73.59550561797752 M85.3932584269663 73.59550561797752 L86.51685393258427 73.59550561797752 M87.64044943820225 73.59550561797752 L88.76404494382024 73.59550561797752 M91.01123595505618 73.59550561797752 L92.13483146067416 73.59550561797752 M93.25842696629215 73.59550561797752 L95.50561797752809 73.59550561797752 M96.62921348314607 73.59550561797752 L98.87640449438203 73.59550561797752 M2.247191011235955 74.71910112359551 L3.370786516853933 74.71910112359551 M4.49438202247191 74.71910112359551 L11.235955056179776 74.71910112359551 M12.359550561797754 74.71910112359551 L13.483146067415731 74.71910112359551 M14.606741573033709 74.71910112359551 L15.730337078651687 74.71910112359551 M20.224719101123597 74.71910112359551 L24.719101123595507 74.71910112359551 M26.966292134831463 74.71910112359551 L29.213483146067418 74.71910112359551 M32.58426966292135 74.71910112359551 L33.70786516853933 74.71910112359551 M37.07865168539326 74.71910112359551 L39.325842696629216 74.71910112359551 M41.57303370786517 74.71910112359551 L42.69662921348315 74.71910112359551 M43.82022471910113 74.71910112359551 L48.31460674157304 74.71910112359551 M51.68539325842697 74.71910112359551 L52.80898876404495 74.71910112359551 M57.30337078651686 74.71910112359551 L59.55056179775281 74.71910112359551 M60.67415730337079 74.71910112359551 L61.79775280898877 74.71910112359551 M64.04494382022472 74.71910112359551 L65.1685393258427 74.71910112359551 M67.41573033707866 74.71910112359551 L70.7865168539326 74.71910112359551 M73.03370786516854 74.71910112359551 L74.15730337078652 74.71910112359551 M77.52808988764045 74.71910112359551 L79.77528089887642 74.71910112359551 M80.89887640449439 74.71910112359551 L84.26966292134833 74.71910112359551 M86.51685393258427 74.71910112359551 L88.76404494382024 74.71910112359551 M89.88764044943821 74.71910112359551 L92.13483146067416 74.71910112359551 M93.25842696629215 74.71910112359551 L94.38202247191012 74.71910112359551 M95.50561797752809 74.71910112359551 L96.62921348314607 74.71910112359551 M0 75.84269662921349 L1.1235955056179776 75.84269662921349 M2.247191011235955 75.84269662921349 L3.370786516853933 75.84269662921349 M4.49438202247191 75.84269662921349 L5.617977528089888 75.84269662921349 M7.865168539325843 75.84269662921349 L10.112359550561798 75.84269662921349 M14.606741573033709 75.84269662921349 L19.10112359550562 75.84269662921349 M20.224719101123597 75.84269662921349 L24.719101123595507 75.84269662921349 M25.842696629213485 75.84269662921349 L26.966292134831463 75.84269662921349 M28.08988764044944 75.84269662921349 L32.58426966292135 75.84269662921349 M33.70786516853933 75.84269662921349 L38.20224719101124 75.84269662921349 M39.325842696629216 75.84269662921349 L41.57303370786517 75.84269662921349 M42.69662921348315 75.84269662921349 L44.943820224719104 75.84269662921349 M46.06741573033708 75.84269662921349 L47.19101123595506 75.84269662921349 M50.56179775280899 75.84269662921349 L51.68539325842697 75.84269662921349 M55.0561797752809 75.84269662921349 L56.17977528089888 75.84269662921349 M57.30337078651686 75.84269662921349 L58.426966292134836 75.84269662921349 M62.921348314606746 75.84269662921349 L66.29213483146069 75.84269662921349 M71.91011235955057 75.84269662921349 L73.03370786516854 75.84269662921349 M74.15730337078652 75.84269662921349 L75.2808988764045 75.84269662921349 M76.40449438202248 75.84269662921349 L78.65168539325843 75.84269662921349 M82.02247191011236 75.84269662921349 L83.14606741573034 75.84269662921349 M85.3932584269663 75.84269662921349 L86.51685393258427 75.84269662921349 M91.01123595505618 75.84269662921349 L93.25842696629215 75.84269662921349 M94.38202247191012 75.84269662921349 L95.50561797752809 75.84269662921349 M0 76.96629213483146 L1.1235955056179776 76.96629213483146 M4.49438202247191 76.96629213483146 L5.617977528089888 76.96629213483146 M6.741573033707866 76.96629213483146 L8.98876404494382 76.96629213483146 M10.112359550561798 76.96629213483146 L11.235955056179776 76.96629213483146 M12.359550561797754 76.96629213483146 L13.483146067415731 76.96629213483146 M14.606741573033709 76.96629213483146 L15.730337078651687 76.96629213483146 M17.97752808988764 76.96629213483146 L22.471910112359552 76.96629213483146 M23.59550561797753 76.96629213483146 L28.08988764044944 76.96629213483146 M34.831460674157306 76.96629213483146 L35.95505617977528 76.96629213483146 M37.07865168539326 76.96629213483146 L39.325842696629216 76.96629213483146 M40.449438202247194 76.96629213483146 L42.69662921348315 76.96629213483146 M46.06741573033708 76.96629213483146 L49.438202247191015 76.96629213483146 M51.68539325842697 76.96629213483146 L56.17977528089888 76.96629213483146 M60.67415730337079 76.96629213483146 L61.79775280898877 76.96629213483146 M64.04494382022472 76.96629213483146 L66.29213483146069 76.96629213483146 M67.41573033707866 76.96629213483146 L68.53932584269663 76.96629213483146 M69.66292134831461 76.96629213483146 L74.15730337078652 76.96629213483146 M78.65168539325843 76.96629213483146 L79.77528089887642 76.96629213483146 M80.89887640449439 76.96629213483146 L82.02247191011236 76.96629213483146 M83.14606741573034 76.96629213483146 L87.64044943820225 76.96629213483146 M89.88764044943821 76.96629213483146 L91.01123595505618 76.96629213483146 M93.25842696629215 76.96629213483146 L100 76.96629213483146 M1.1235955056179776 78.08988764044943 L3.370786516853933 78.08988764044943 M5.617977528089888 78.08988764044943 L6.741573033707866 78.08988764044943 M7.865168539325843 78.08988764044943 L8.98876404494382 78.08988764044943 M13.483146067415731 78.08988764044943 L14.606741573033709 78.08988764044943 M21.348314606741575 78.08988764044943 L22.471910112359552 78.08988764044943 M25.842696629213485 78.08988764044943 L26.966292134831463 78.08988764044943 M30.337078651685395 78.08988764044943 L35.95505617977528 78.08988764044943 M37.07865168539326 78.08988764044943 L38.20224719101124 78.08988764044943 M39.325842696629216 78.08988764044943 L42.69662921348315 78.08988764044943 M44.943820224719104 78.08988764044943 L48.31460674157304 78.08988764044943 M53.932584269662925 78.08988764044943 L56.17977528089888 78.08988764044943 M57.30337078651686 78.08988764044943 L59.55056179775281 78.08988764044943 M62.921348314606746 78.08988764044943 L64.04494382022472 78.08988764044943 M77.52808988764045 78.08988764044943 L78.65168539325843 78.08988764044943 M79.77528089887642 78.08988764044943 L82.02247191011236 78.08988764044943 M84.26966292134833 78.08988764044943 L85.3932584269663 78.08988764044943 M89.88764044943821 78.08988764044943 L91.01123595505618 78.08988764044943 M92.13483146067416 78.08988764044943 L95.50561797752809 78.08988764044943 M1.1235955056179776 79.21348314606742 L5.617977528089888 79.21348314606742 M6.741573033707866 79.21348314606742 L7.865168539325843 79.21348314606742 M8.98876404494382 79.21348314606742 L10.112359550561798 79.21348314606742 M16.853932584269664 79.21348314606742 L19.10112359550562 79.21348314606742 M24.719101123595507 79.21348314606742 L28.08988764044944 79.21348314606742 M29.213483146067418 79.21348314606742 L30.337078651685395 79.21348314606742 M34.831460674157306 79.21348314606742 L35.95505617977528 79.21348314606742 M40.449438202247194 79.21348314606742 L42.69662921348315 79.21348314606742 M43.82022471910113 79.21348314606742 L44.943820224719104 79.21348314606742 M48.31460674157304 79.21348314606742 L49.438202247191015 79.21348314606742 M50.56179775280899 79.21348314606742 L51.68539325842697 79.21348314606742 M52.80898876404495 79.21348314606742 L59.55056179775281 79.21348314606742 M62.921348314606746 79.21348314606742 L64.04494382022472 79.21348314606742 M65.1685393258427 79.21348314606742 L69.66292134831461 79.21348314606742 M70.7865168539326 79.21348314606742 L74.15730337078652 79.21348314606742 M75.2808988764045 79.21348314606742 L76.40449438202248 79.21348314606742 M79.77528089887642 79.21348314606742 L80.89887640449439 79.21348314606742 M82.02247191011236 79.21348314606742 L85.3932584269663 79.21348314606742 M86.51685393258427 79.21348314606742 L87.64044943820225 79.21348314606742 M89.88764044943821 79.21348314606742 L91.01123595505618 79.21348314606742 M93.25842696629215 79.21348314606742 L95.50561797752809 79.21348314606742 M96.62921348314607 79.21348314606742 L97.75280898876406 79.21348314606742 M1.1235955056179776 80.3370786516854 L3.370786516853933 80.3370786516854 M4.49438202247191 80.3370786516854 L6.741573033707866 80.3370786516854 M7.865168539325843 80.3370786516854 L8.98876404494382 80.3370786516854 M11.235955056179776 80.3370786516854 L15.730337078651687 80.3370786516854 M21.348314606741575 80.3370786516854 L26.966292134831463 80.3370786516854 M30.337078651685395 80.3370786516854 L31.460674157303373 80.3370786516854 M32.58426966292135 80.3370786516854 L34.831460674157306 80.3370786516854 M35.95505617977528 80.3370786516854 L39.325842696629216 80.3370786516854 M42.69662921348315 80.3370786516854 L43.82022471910113 80.3370786516854 M46.06741573033708 80.3370786516854 L48.31460674157304 80.3370786516854 M49.438202247191015 80.3370786516854 L50.56179775280899 80.3370786516854 M51.68539325842697 80.3370786516854 L53.932584269662925 80.3370786516854 M57.30337078651686 80.3370786516854 L58.426966292134836 80.3370786516854 M59.55056179775281 80.3370786516854 L60.67415730337079 80.3370786516854 M62.921348314606746 80.3370786516854 L64.04494382022472 80.3370786516854 M66.29213483146069 80.3370786516854 L67.41573033707866 80.3370786516854 M68.53932584269663 80.3370786516854 L70.7865168539326 80.3370786516854 M73.03370786516854 80.3370786516854 L74.15730337078652 80.3370786516854 M75.2808988764045 80.3370786516854 L77.52808988764045 80.3370786516854 M78.65168539325843 80.3370786516854 L79.77528089887642 80.3370786516854 M84.26966292134833 80.3370786516854 L86.51685393258427 80.3370786516854 M92.13483146067416 80.3370786516854 L93.25842696629215 80.3370786516854 M95.50561797752809 80.3370786516854 L96.62921348314607 80.3370786516854 M97.75280898876406 80.3370786516854 L100 80.3370786516854 M1.1235955056179776 81.46067415730337 L2.247191011235955 81.46067415730337 M3.370786516853933 81.46067415730337 L7.865168539325843 81.46067415730337 M14.606741573033709 81.46067415730337 L16.853932584269664 81.46067415730337 M17.97752808988764 81.46067415730337 L19.10112359550562 81.46067415730337 M20.224719101123597 81.46067415730337 L22.471910112359552 81.46067415730337 M28.08988764044944 81.46067415730337 L30.337078651685395 81.46067415730337 M31.460674157303373 81.46067415730337 L34.831460674157306 81.46067415730337 M39.325842696629216 81.46067415730337 L41.57303370786517 81.46067415730337 M42.69662921348315 81.46067415730337 L43.82022471910113 81.46067415730337 M46.06741573033708 81.46067415730337 L49.438202247191015 81.46067415730337 M51.68539325842697 81.46067415730337 L52.80898876404495 81.46067415730337 M53.932584269662925 81.46067415730337 L55.0561797752809 81.46067415730337 M59.55056179775281 81.46067415730337 L60.67415730337079 81.46067415730337 M64.04494382022472 81.46067415730337 L66.29213483146069 81.46067415730337 M70.7865168539326 81.46067415730337 L75.2808988764045 81.46067415730337 M77.52808988764045 81.46067415730337 L78.65168539325843 81.46067415730337 M82.02247191011236 81.46067415730337 L83.14606741573034 81.46067415730337 M86.51685393258427 81.46067415730337 L91.01123595505618 81.46067415730337 M97.75280898876406 81.46067415730337 L100 81.46067415730337 M0 82.58426966292134 L1.1235955056179776 82.58426966292134 M3.370786516853933 82.58426966292134 L4.49438202247191 82.58426966292134 M5.617977528089888 82.58426966292134 L6.741573033707866 82.58426966292134 M7.865168539325843 82.58426966292134 L8.98876404494382 82.58426966292134 M11.235955056179776 82.58426966292134 L12.359550561797754 82.58426966292134 M13.483146067415731 82.58426966292134 L17.97752808988764 82.58426966292134 M19.10112359550562 82.58426966292134 L20.224719101123597 82.58426966292134 M22.471910112359552 82.58426966292134 L23.59550561797753 82.58426966292134 M24.719101123595507 82.58426966292134 L25.842696629213485 82.58426966292134 M26.966292134831463 82.58426966292134 L32.58426966292135 82.58426966292134 M33.70786516853933 82.58426966292134 L35.95505617977528 82.58426966292134 M37.07865168539326 82.58426966292134 L38.20224719101124 82.58426966292134 M41.57303370786517 82.58426966292134 L42.69662921348315 82.58426966292134 M46.06741573033708 82.58426966292134 L48.31460674157304 82.58426966292134 M49.438202247191015 82.58426966292134 L50.56179775280899 82.58426966292134 M52.80898876404495 82.58426966292134 L55.0561797752809 82.58426966292134 M57.30337078651686 82.58426966292134 L58.426966292134836 82.58426966292134 M59.55056179775281 82.58426966292134 L62.921348314606746 82.58426966292134 M64.04494382022472 82.58426966292134 L65.1685393258427 82.58426966292134 M66.29213483146069 82.58426966292134 L67.41573033707866 82.58426966292134 M69.66292134831461 82.58426966292134 L71.91011235955057 82.58426966292134 M74.15730337078652 82.58426966292134 L79.77528089887642 82.58426966292134 M80.89887640449439 82.58426966292134 L82.02247191011236 82.58426966292134 M83.14606741573034 82.58426966292134 L84.26966292134833 82.58426966292134 M85.3932584269663 82.58426966292134 L86.51685393258427 82.58426966292134 M87.64044943820225 82.58426966292134 L89.88764044943821 82.58426966292134 M93.25842696629215 82.58426966292134 L96.62921348314607 82.58426966292134 M0 83.70786516853933 L2.247191011235955 83.70786516853933 M3.370786516853933 83.70786516853933 L4.49438202247191 83.70786516853933 M5.617977528089888 83.70786516853933 L10.112359550561798 83.70786516853933 M12.359550561797754 83.70786516853933 L14.606741573033709 83.70786516853933 M16.853932584269664 83.70786516853933 L17.97752808988764 83.70786516853933 M20.224719101123597 83.70786516853933 L21.348314606741575 83.70786516853933 M22.471910112359552 83.70786516853933 L24.719101123595507 83.70786516853933 M26.966292134831463 83.70786516853933 L30.337078651685395 83.70786516853933 M31.460674157303373 83.70786516853933 L33.70786516853933 83.70786516853933 M34.831460674157306 83.70786516853933 L38.20224719101124 83.70786516853933 M40.449438202247194 83.70786516853933 L46.06741573033708 83.70786516853933 M50.56179775280899 83.70786516853933 L51.68539325842697 83.70786516853933 M52.80898876404495 83.70786516853933 L53.932584269662925 83.70786516853933 M55.0561797752809 83.70786516853933 L57.30337078651686 83.70786516853933 M61.79775280898877 83.70786516853933 L64.04494382022472 83.70786516853933 M66.29213483146069 83.70786516853933 L71.91011235955057 83.70786516853933 M78.65168539325843 83.70786516853933 L80.89887640449439 83.70786516853933 M82.02247191011236 83.70786516853933 L83.14606741573034 83.70786516853933 M86.51685393258427 83.70786516853933 L87.64044943820225 83.70786516853933 M89.88764044943821 83.70786516853933 L93.25842696629215 83.70786516853933 M95.50561797752809 83.70786516853933 L97.75280898876406 83.70786516853933 M0 84.83146067415731 L1.1235955056179776 84.83146067415731 M12.359550561797754 84.83146067415731 L15.730337078651687 84.83146067415731 M17.97752808988764 84.83146067415731 L21.348314606741575 84.83146067415731 M22.471910112359552 84.83146067415731 L25.842696629213485 84.83146067415731 M28.08988764044944 84.83146067415731 L29.213483146067418 84.83146067415731 M35.95505617977528 84.83146067415731 L40.449438202247194 84.83146067415731 M43.82022471910113 84.83146067415731 L44.943820224719104 84.83146067415731 M47.19101123595506 84.83146067415731 L48.31460674157304 84.83146067415731 M49.438202247191015 84.83146067415731 L51.68539325842697 84.83146067415731 M53.932584269662925 84.83146067415731 L55.0561797752809 84.83146067415731 M56.17977528089888 84.83146067415731 L57.30337078651686 84.83146067415731 M58.426966292134836 84.83146067415731 L59.55056179775281 84.83146067415731 M62.921348314606746 84.83146067415731 L66.29213483146069 84.83146067415731 M69.66292134831461 84.83146067415731 L74.15730337078652 84.83146067415731 M76.40449438202248 84.83146067415731 L77.52808988764045 84.83146067415731 M78.65168539325843 84.83146067415731 L79.77528089887642 84.83146067415731 M83.14606741573034 84.83146067415731 L84.26966292134833 84.83146067415731 M85.3932584269663 84.83146067415731 L88.76404494382024 84.83146067415731 M89.88764044943821 84.83146067415731 L91.01123595505618 84.83146067415731 M94.38202247191012 84.83146067415731 L96.62921348314607 84.83146067415731 M98.87640449438203 84.83146067415731 L100 84.83146067415731 M0 85.95505617977528 L2.247191011235955 85.95505617977528 M5.617977528089888 85.95505617977528 L7.865168539325843 85.95505617977528 M11.235955056179776 85.95505617977528 L13.483146067415731 85.95505617977528 M14.606741573033709 85.95505617977528 L15.730337078651687 85.95505617977528 M16.853932584269664 85.95505617977528 L19.10112359550562 85.95505617977528 M20.224719101123597 85.95505617977528 L22.471910112359552 85.95505617977528 M23.59550561797753 85.95505617977528 L25.842696629213485 85.95505617977528 M26.966292134831463 85.95505617977528 L28.08988764044944 85.95505617977528 M29.213483146067418 85.95505617977528 L30.337078651685395 85.95505617977528 M32.58426966292135 85.95505617977528 L34.831460674157306 85.95505617977528 M37.07865168539326 85.95505617977528 L39.325842696629216 85.95505617977528 M40.449438202247194 85.95505617977528 L43.82022471910113 85.95505617977528 M46.06741573033708 85.95505617977528 L49.438202247191015 85.95505617977528 M52.80898876404495 85.95505617977528 L56.17977528089888 85.95505617977528 M59.55056179775281 85.95505617977528 L61.79775280898877 85.95505617977528 M62.921348314606746 85.95505617977528 L64.04494382022472 85.95505617977528 M65.1685393258427 85.95505617977528 L66.29213483146069 85.95505617977528 M70.7865168539326 85.95505617977528 L71.91011235955057 85.95505617977528 M76.40449438202248 85.95505617977528 L78.65168539325843 85.95505617977528 M83.14606741573034 85.95505617977528 L88.76404494382024 85.95505617977528 M93.25842696629215 85.95505617977528 L94.38202247191012 85.95505617977528 M95.50561797752809 85.95505617977528 L97.75280898876406 85.95505617977528 M0 87.07865168539325 L1.1235955056179776 87.07865168539325 M2.247191011235955 87.07865168539325 L5.617977528089888 87.07865168539325 M7.865168539325843 87.07865168539325 L11.235955056179776 87.07865168539325 M13.483146067415731 87.07865168539325 L14.606741573033709 87.07865168539325 M15.730337078651687 87.07865168539325 L17.97752808988764 87.07865168539325 M24.719101123595507 87.07865168539325 L25.842696629213485 87.07865168539325 M30.337078651685395 87.07865168539325 L31.460674157303373 87.07865168539325 M32.58426966292135 87.07865168539325 L33.70786516853933 87.07865168539325 M34.831460674157306 87.07865168539325 L35.95505617977528 87.07865168539325 M37.07865168539326 87.07865168539325 L42.69662921348315 87.07865168539325 M44.943820224719104 87.07865168539325 L46.06741573033708 87.07865168539325 M47.19101123595506 87.07865168539325 L48.31460674157304 87.07865168539325 M49.438202247191015 87.07865168539325 L50.56179775280899 87.07865168539325 M53.932584269662925 87.07865168539325 L55.0561797752809 87.07865168539325 M57.30337078651686 87.07865168539325 L58.426966292134836 87.07865168539325 M60.67415730337079 87.07865168539325 L64.04494382022472 87.07865168539325 M69.66292134831461 87.07865168539325 L73.03370786516854 87.07865168539325 M77.52808988764045 87.07865168539325 L82.02247191011236 87.07865168539325 M83.14606741573034 87.07865168539325 L84.26966292134833 87.07865168539325 M87.64044943820225 87.07865168539325 L88.76404494382024 87.07865168539325 M89.88764044943821 87.07865168539325 L91.01123595505618 87.07865168539325 M93.25842696629215 87.07865168539325 L95.50561797752809 87.07865168539325 M96.62921348314607 87.07865168539325 L97.75280898876406 87.07865168539325 M98.87640449438203 87.07865168539325 L100 87.07865168539325 M0 88.20224719101124 L1.1235955056179776 88.20224719101124 M3.370786516853933 88.20224719101124 L4.49438202247191 88.20224719101124 M6.741573033707866 88.20224719101124 L7.865168539325843 88.20224719101124 M10.112359550561798 88.20224719101124 L13.483146067415731 88.20224719101124 M14.606741573033709 88.20224719101124 L16.853932584269664 88.20224719101124 M17.97752808988764 88.20224719101124 L19.10112359550562 88.20224719101124 M20.224719101123597 88.20224719101124 L21.348314606741575 88.20224719101124 M24.719101123595507 88.20224719101124 L29.213483146067418 88.20224719101124 M30.337078651685395 88.20224719101124 L31.460674157303373 88.20224719101124 M39.325842696629216 88.20224719101124 L40.449438202247194 88.20224719101124 M41.57303370786517 88.20224719101124 L42.69662921348315 88.20224719101124 M46.06741573033708 88.20224719101124 L51.68539325842697 88.20224719101124 M53.932584269662925 88.20224719101124 L57.30337078651686 88.20224719101124 M58.426966292134836 88.20224719101124 L59.55056179775281 88.20224719101124 M60.67415730337079 88.20224719101124 L61.79775280898877 88.20224719101124 M64.04494382022472 88.20224719101124 L65.1685393258427 88.20224719101124 M67.41573033707866 88.20224719101124 L68.53932584269663 88.20224719101124 M75.2808988764045 88.20224719101124 L77.52808988764045 88.20224719101124 M83.14606741573034 88.20224719101124 L84.26966292134833 88.20224719101124 M95.50561797752809 88.20224719101124 L96.62921348314607 88.20224719101124 M97.75280898876406 88.20224719101124 L98.87640449438203 88.20224719101124 M0 89.32584269662922 L2.247191011235955 89.32584269662922 M4.49438202247191 89.32584269662922 L6.741573033707866 89.32584269662922 M8.98876404494382 89.32584269662922 L11.235955056179776 89.32584269662922 M16.853932584269664 89.32584269662922 L21.348314606741575 89.32584269662922 M24.719101123595507 89.32584269662922 L26.966292134831463 89.32584269662922 M28.08988764044944 89.32584269662922 L29.213483146067418 89.32584269662922 M32.58426966292135 89.32584269662922 L38.20224719101124 89.32584269662922 M41.57303370786517 89.32584269662922 L48.31460674157304 89.32584269662922 M51.68539325842697 89.32584269662922 L52.80898876404495 89.32584269662922 M53.932584269662925 89.32584269662922 L56.17977528089888 89.32584269662922 M58.426966292134836 89.32584269662922 L67.41573033707866 89.32584269662922 M68.53932584269663 89.32584269662922 L75.2808988764045 89.32584269662922 M76.40449438202248 89.32584269662922 L77.52808988764045 89.32584269662922 M78.65168539325843 89.32584269662922 L80.89887640449439 89.32584269662922 M82.02247191011236 89.32584269662922 L84.26966292134833 89.32584269662922 M85.3932584269663 89.32584269662922 L86.51685393258427 89.32584269662922 M88.76404494382024 89.32584269662922 L93.25842696629215 89.32584269662922 M95.50561797752809 89.32584269662922 L96.62921348314607 89.32584269662922 M97.75280898876406 89.32584269662922 L98.87640449438203 89.32584269662922 M0 90.4494382022472 L1.1235955056179776 90.4494382022472 M3.370786516853933 90.4494382022472 L4.49438202247191 90.4494382022472 M6.741573033707866 90.4494382022472 L7.865168539325843 90.4494382022472 M8.98876404494382 90.4494382022472 L13.483146067415731 90.4494382022472 M15.730337078651687 90.4494382022472 L16.853932584269664 90.4494382022472 M19.10112359550562 90.4494382022472 L21.348314606741575 90.4494382022472 M22.471910112359552 90.4494382022472 L23.59550561797753 90.4494382022472 M24.719101123595507 90.4494382022472 L25.842696629213485 90.4494382022472 M26.966292134831463 90.4494382022472 L28.08988764044944 90.4494382022472 M29.213483146067418 90.4494382022472 L30.337078651685395 90.4494382022472 M31.460674157303373 90.4494382022472 L43.82022471910113 90.4494382022472 M47.19101123595506 90.4494382022472 L50.56179775280899 90.4494382022472 M52.80898876404495 90.4494382022472 L55.0561797752809 90.4494382022472 M56.17977528089888 90.4494382022472 L57.30337078651686 90.4494382022472 M59.55056179775281 90.4494382022472 L66.29213483146069 90.4494382022472 M67.41573033707866 90.4494382022472 L68.53932584269663 90.4494382022472 M73.03370786516854 90.4494382022472 L75.2808988764045 90.4494382022472 M76.40449438202248 90.4494382022472 L78.65168539325843 90.4494382022472 M80.89887640449439 90.4494382022472 L82.02247191011236 90.4494382022472 M84.26966292134833 90.4494382022472 L100 90.4494382022472 M8.98876404494382 91.57303370786516 L10.112359550561798 91.57303370786516 M11.235955056179776 91.57303370786516 L12.359550561797754 91.57303370786516 M13.483146067415731 91.57303370786516 L14.606741573033709 91.57303370786516 M15.730337078651687 91.57303370786516 L17.97752808988764 91.57303370786516 M23.59550561797753 91.57303370786516 L24.719101123595507 91.57303370786516 M31.460674157303373 91.57303370786516 L32.58426966292135 91.57303370786516 M35.95505617977528 91.57303370786516 L37.07865168539326 91.57303370786516 M38.20224719101124 91.57303370786516 L42.69662921348315 91.57303370786516 M43.82022471910113 91.57303370786516 L44.943820224719104 91.57303370786516 M46.06741573033708 91.57303370786516 L48.31460674157304 91.57303370786516 M49.438202247191015 91.57303370786516 L51.68539325842697 91.57303370786516 M55.0561797752809 91.57303370786516 L56.17977528089888 91.57303370786516 M60.67415730337079 91.57303370786516 L61.79775280898877 91.57303370786516 M65.1685393258427 91.57303370786516 L68.53932584269663 91.57303370786516 M71.91011235955057 91.57303370786516 L73.03370786516854 91.57303370786516 M74.15730337078652 91.57303370786516 L82.02247191011236 91.57303370786516 M85.3932584269663 91.57303370786516 L86.51685393258427 91.57303370786516 M87.64044943820225 91.57303370786516 L91.01123595505618 91.57303370786516 M94.38202247191012 91.57303370786516 L100 91.57303370786516 M0 92.69662921348315 L7.865168539325843 92.69662921348315 M10.112359550561798 92.69662921348315 L14.606741573033709 92.69662921348315 M19.10112359550562 92.69662921348315 L20.224719101123597 92.69662921348315 M21.348314606741575 92.69662921348315 L25.842696629213485 92.69662921348315 M28.08988764044944 92.69662921348315 L32.58426966292135 92.69662921348315 M33.70786516853933 92.69662921348315 L34.831460674157306 92.69662921348315 M35.95505617977528 92.69662921348315 L37.07865168539326 92.69662921348315 M38.20224719101124 92.69662921348315 L39.325842696629216 92.69662921348315 M42.69662921348315 92.69662921348315 L44.943820224719104 92.69662921348315 M46.06741573033708 92.69662921348315 L50.56179775280899 92.69662921348315 M51.68539325842697 92.69662921348315 L52.80898876404495 92.69662921348315 M56.17977528089888 92.69662921348315 L59.55056179775281 92.69662921348315 M60.67415730337079 92.69662921348315 L61.79775280898877 92.69662921348315 M62.921348314606746 92.69662921348315 L64.04494382022472 92.69662921348315 M65.1685393258427 92.69662921348315 L70.7865168539326 92.69662921348315 M71.91011235955057 92.69662921348315 L74.15730337078652 92.69662921348315 M75.2808988764045 92.69662921348315 L77.52808988764045 92.69662921348315 M78.65168539325843 92.69662921348315 L79.77528089887642 92.69662921348315 M80.89887640449439 92.69662921348315 L85.3932584269663 92.69662921348315 M86.51685393258427 92.69662921348315 L87.64044943820225 92.69662921348315 M89.88764044943821 92.69662921348315 L91.01123595505618 92.69662921348315 M92.13483146067416 92.69662921348315 L93.25842696629215 92.69662921348315 M94.38202247191012 92.69662921348315 L95.50561797752809 92.69662921348315 M96.62921348314607 92.69662921348315 L97.75280898876406 92.69662921348315 M0 93.82022471910113 L1.1235955056179776 93.82022471910113 M6.741573033707866 93.82022471910113 L7.865168539325843 93.82022471910113 M8.98876404494382 93.82022471910113 L11.235955056179776 93.82022471910113 M13.483146067415731 93.82022471910113 L14.606741573033709 93.82022471910113 M16.853932584269664 93.82022471910113 L17.97752808988764 93.82022471910113 M19.10112359550562 93.82022471910113 L20.224719101123597 93.82022471910113 M21.348314606741575 93.82022471910113 L25.842696629213485 93.82022471910113 M26.966292134831463 93.82022471910113 L28.08988764044944 93.82022471910113 M29.213483146067418 93.82022471910113 L30.337078651685395 93.82022471910113 M31.460674157303373 93.82022471910113 L32.58426966292135 93.82022471910113 M35.95505617977528 93.82022471910113 L38.20224719101124 93.82022471910113 M40.449438202247194 93.82022471910113 L41.57303370786517 93.82022471910113 M42.69662921348315 93.82022471910113 L43.82022471910113 93.82022471910113 M47.19101123595506 93.82022471910113 L49.438202247191015 93.82022471910113 M50.56179775280899 93.82022471910113 L55.0561797752809 93.82022471910113 M56.17977528089888 93.82022471910113 L58.426966292134836 93.82022471910113 M60.67415730337079 93.82022471910113 L61.79775280898877 93.82022471910113 M65.1685393258427 93.82022471910113 L67.41573033707866 93.82022471910113 M75.2808988764045 93.82022471910113 L76.40449438202248 93.82022471910113 M84.26966292134833 93.82022471910113 L86.51685393258427 93.82022471910113 M87.64044943820225 93.82022471910113 L91.01123595505618 93.82022471910113 M94.38202247191012 93.82022471910113 L100 93.82022471910113 M0 94.9438202247191 L1.1235955056179776 94.9438202247191 M2.247191011235955 94.9438202247191 L5.617977528089888 94.9438202247191 M6.741573033707866 94.9438202247191 L7.865168539325843 94.9438202247191 M8.98876404494382 94.9438202247191 L10.112359550561798 94.9438202247191 M13.483146067415731 94.9438202247191 L17.97752808988764 94.9438202247191 M21.348314606741575 94.9438202247191 L22.471910112359552 94.9438202247191 M23.59550561797753 94.9438202247191 L25.842696629213485 94.9438202247191 M31.460674157303373 94.9438202247191 L37.07865168539326 94.9438202247191 M39.325842696629216 94.9438202247191 L41.57303370786517 94.9438202247191 M42.69662921348315 94.9438202247191 L43.82022471910113 94.9438202247191 M48.31460674157304 94.9438202247191 L49.438202247191015 94.9438202247191 M50.56179775280899 94.9438202247191 L55.0561797752809 94.9438202247191 M59.55056179775281 94.9438202247191 L66.29213483146069 94.9438202247191 M69.66292134831461 94.9438202247191 L71.91011235955057 94.9438202247191 M76.40449438202248 94.9438202247191 L78.65168539325843 94.9438202247191 M84.26966292134833 94.9438202247191 L85.3932584269663 94.9438202247191 M86.51685393258427 94.9438202247191 L87.64044943820225 94.9438202247191 M89.88764044943821 94.9438202247191 L95.50561797752809 94.9438202247191 M98.87640449438203 94.9438202247191 L100 94.9438202247191 M0 96.06741573033707 L1.1235955056179776 96.06741573033707 M2.247191011235955 96.06741573033707 L5.617977528089888 96.06741573033707 M6.741573033707866 96.06741573033707 L7.865168539325843 96.06741573033707 M8.98876404494382 96.06741573033707 L11.235955056179776 96.06741573033707 M13.483146067415731 96.06741573033707 L14.606741573033709 96.06741573033707 M16.853932584269664 96.06741573033707 L17.97752808988764 96.06741573033707 M21.348314606741575 96.06741573033707 L22.471910112359552 96.06741573033707 M23.59550561797753 96.06741573033707 L26.966292134831463 96.06741573033707 M28.08988764044944 96.06741573033707 L29.213483146067418 96.06741573033707 M30.337078651685395 96.06741573033707 L31.460674157303373 96.06741573033707 M34.831460674157306 96.06741573033707 L37.07865168539326 96.06741573033707 M38.20224719101124 96.06741573033707 L39.325842696629216 96.06741573033707 M40.449438202247194 96.06741573033707 L42.69662921348315 96.06741573033707 M43.82022471910113 96.06741573033707 L44.943820224719104 96.06741573033707 M47.19101123595506 96.06741573033707 L48.31460674157304 96.06741573033707 M52.80898876404495 96.06741573033707 L56.17977528089888 96.06741573033707 M57.30337078651686 96.06741573033707 L59.55056179775281 96.06741573033707 M60.67415730337079 96.06741573033707 L61.79775280898877 96.06741573033707 M62.921348314606746 96.06741573033707 L64.04494382022472 96.06741573033707 M65.1685393258427 96.06741573033707 L66.29213483146069 96.06741573033707 M74.15730337078652 96.06741573033707 L79.77528089887642 96.06741573033707 M80.89887640449439 96.06741573033707 L82.02247191011236 96.06741573033707 M83.14606741573034 96.06741573033707 L84.26966292134833 96.06741573033707 M88.76404494382024 96.06741573033707 L89.88764044943821 96.06741573033707 M93.25842696629215 96.06741573033707 L94.38202247191012 96.06741573033707 M95.50561797752809 96.06741573033707 L96.62921348314607 96.06741573033707 M97.75280898876406 96.06741573033707 L98.87640449438203 96.06741573033707 M0 97.19101123595506 L1.1235955056179776 97.19101123595506 M2.247191011235955 97.19101123595506 L5.617977528089888 97.19101123595506 M6.741573033707866 97.19101123595506 L7.865168539325843 97.19101123595506 M8.98876404494382 97.19101123595506 L10.112359550561798 97.19101123595506 M11.235955056179776 97.19101123595506 L14.606741573033709 97.19101123595506 M17.97752808988764 97.19101123595506 L19.10112359550562 97.19101123595506 M21.348314606741575 97.19101123595506 L23.59550561797753 97.19101123595506 M24.719101123595507 97.19101123595506 L28.08988764044944 97.19101123595506 M29.213483146067418 97.19101123595506 L30.337078651685395 97.19101123595506 M31.460674157303373 97.19101123595506 L33.70786516853933 97.19101123595506 M34.831460674157306 97.19101123595506 L38.20224719101124 97.19101123595506 M39.325842696629216 97.19101123595506 L42.69662921348315 97.19101123595506 M43.82022471910113 97.19101123595506 L44.943820224719104 97.19101123595506 M46.06741573033708 97.19101123595506 L47.19101123595506 97.19101123595506 M49.438202247191015 97.19101123595506 L53.932584269662925 97.19101123595506 M56.17977528089888 97.19101123595506 L61.79775280898877 97.19101123595506 M62.921348314606746 97.19101123595506 L64.04494382022472 97.19101123595506 M67.41573033707866 97.19101123595506 L68.53932584269663 97.19101123595506 M69.66292134831461 97.19101123595506 L71.91011235955057 97.19101123595506 M73.03370786516854 97.19101123595506 L74.15730337078652 97.19101123595506 M77.52808988764045 97.19101123595506 L79.77528089887642 97.19101123595506 M80.89887640449439 97.19101123595506 L82.02247191011236 97.19101123595506 M88.76404494382024 97.19101123595506 L91.01123595505618 97.19101123595506 M93.25842696629215 97.19101123595506 L96.62921348314607 97.19101123595506 M97.75280898876406 97.19101123595506 L98.87640449438203 97.19101123595506 M0 98.31460674157304 L1.1235955056179776 98.31460674157304 M6.741573033707866 98.31460674157304 L7.865168539325843 98.31460674157304 M10.112359550561798 98.31460674157304 L14.606741573033709 98.31460674157304 M15.730337078651687 98.31460674157304 L19.10112359550562 98.31460674157304 M21.348314606741575 98.31460674157304 L26.966292134831463 98.31460674157304 M32.58426966292135 98.31460674157304 L34.831460674157306 98.31460674157304 M37.07865168539326 98.31460674157304 L40.449438202247194 98.31460674157304 M41.57303370786517 98.31460674157304 L43.82022471910113 98.31460674157304 M44.943820224719104 98.31460674157304 L47.19101123595506 98.31460674157304 M50.56179775280899 98.31460674157304 L51.68539325842697 98.31460674157304 M52.80898876404495 98.31460674157304 L53.932584269662925 98.31460674157304 M57.30337078651686 98.31460674157304 L58.426966292134836 98.31460674157304 M66.29213483146069 98.31460674157304 L67.41573033707866 98.31460674157304 M68.53932584269663 98.31460674157304 L69.66292134831461 98.31460674157304 M70.7865168539326 98.31460674157304 L73.03370786516854 98.31460674157304 M74.15730337078652 98.31460674157304 L77.52808988764045 98.31460674157304 M78.65168539325843 98.31460674157304 L79.77528089887642 98.31460674157304 M82.02247191011236 98.31460674157304 L87.64044943820225 98.31460674157304 M88.76404494382024 98.31460674157304 L91.01123595505618 98.31460674157304 M92.13483146067416 98.31460674157304 L93.25842696629215 98.31460674157304 M95.50561797752809 98.31460674157304 L96.62921348314607 98.31460674157304 M97.75280898876406 98.31460674157304 L98.87640449438203 98.31460674157304 M0 99.43820224719101 L7.865168539325843 99.43820224719101 M8.98876404494382 99.43820224719101 L11.235955056179776 99.43820224719101 M13.483146067415731 99.43820224719101 L14.606741573033709 99.43820224719101 M16.853932584269664 99.43820224719101 L17.97752808988764 99.43820224719101 M20.224719101123597 99.43820224719101 L21.348314606741575 99.43820224719101 M25.842696629213485 99.43820224719101 L26.966292134831463 99.43820224719101 M28.08988764044944 99.43820224719101 L29.213483146067418 99.43820224719101 M34.831460674157306 99.43820224719101 L35.95505617977528 99.43820224719101 M39.325842696629216 99.43820224719101 L41.57303370786517 99.43820224719101 M43.82022471910113 99.43820224719101 L44.943820224719104 99.43820224719101 M47.19101123595506 99.43820224719101 L49.438202247191015 99.43820224719101 M51.68539325842697 99.43820224719101 L52.80898876404495 99.43820224719101 M53.932584269662925 99.43820224719101 L56.17977528089888 99.43820224719101 M59.55056179775281 99.43820224719101 L61.79775280898877 99.43820224719101 M62.921348314606746 99.43820224719101 L65.1685393258427 99.43820224719101 M67.41573033707866 99.43820224719101 L68.53932584269663 99.43820224719101 M69.66292134831461 99.43820224719101 L71.91011235955057 99.43820224719101 M73.03370786516854 99.43820224719101 L75.2808988764045 99.43820224719101 M76.40449438202248 99.43820224719101 L77.52808988764045 99.43820224719101 M78.65168539325843 99.43820224719101 L79.77528089887642 99.43820224719101 M84.26966292134833 99.43820224719101 L85.3932584269663 99.43820224719101 M86.51685393258427 99.43820224719101 L88.76404494382024 99.43820224719101 M95.50561797752809 99.43820224719101 L97.75280898876406 99.43820224719101 "
+                        fill={
+                          Array [
+                            0,
+                            4278190080,
+                          ]
+                        }
+                        fillOpacity={1}
+                        fillRule={1}
+                        matrix={
+                          Array [
+                            1,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                          ]
+                        }
+                        opacity={1}
+                        originX={0}
+                        originY={0}
+                        propList={
+                          Array [
+                            "stroke",
+                            "strokeWidth",
+                          ]
+                        }
+                        rotation={0}
+                        scaleX={1}
+                        scaleY={1}
+                        skewX={0}
+                        skewY={0}
+                        stroke={
+                          Array [
+                            0,
+                            4278190080,
+                          ]
+                        }
+                        strokeDasharray={null}
+                        strokeDashoffset={null}
+                        strokeLinecap={0}
+                        strokeLinejoin={0}
+                        strokeMiterlimit={4}
+                        strokeOpacity={1}
+                        strokeWidth={1.1235955056179776}
+                        vectorEffect={0}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>,
+  <View
+    pointerEvents="auto"
+    style={
+      Object {
+        "alignItems": undefined,
+        "backgroundColor": "#FFFFFF",
+        "borderRadius": undefined,
+        "flex": undefined,
+        "flexDirection": undefined,
+        "height": undefined,
+        "justifyContent": undefined,
+        "margin": undefined,
+        "marginBottom": undefined,
+        "marginLeft": undefined,
+        "marginRight": undefined,
+        "marginTop": undefined,
+        "padding": undefined,
+        "paddingBottom": undefined,
+        "paddingHorizontal": undefined,
+        "paddingLeft": undefined,
+        "paddingRight": undefined,
+        "paddingTop": 15,
+        "width": undefined,
+      }
+    }
+  >
+    <View
+      pointerEvents="auto"
+      style={
+        Object {
+          "alignItems": undefined,
+          "backgroundColor": undefined,
+          "borderRadius": undefined,
+          "flex": undefined,
+          "flexDirection": "row",
+          "height": undefined,
+          "justifyContent": undefined,
+          "margin": undefined,
+          "marginBottom": undefined,
+          "marginLeft": undefined,
+          "marginRight": undefined,
+          "marginTop": undefined,
+          "padding": 15,
+          "paddingBottom": 32,
+          "paddingHorizontal": undefined,
+          "paddingLeft": undefined,
+          "paddingRight": undefined,
+          "paddingTop": undefined,
+          "width": undefined,
+        }
+      }
+    >
+      <View
+        pointerEvents="auto"
+        style={
+          Object {
+            "alignItems": undefined,
+            "backgroundColor": undefined,
+            "borderRadius": undefined,
+            "flex": 1,
+            "flexDirection": undefined,
+            "height": undefined,
+            "justifyContent": undefined,
+            "margin": undefined,
+            "marginBottom": undefined,
+            "marginLeft": undefined,
+            "marginRight": 15,
+            "marginTop": undefined,
+            "padding": undefined,
+            "paddingBottom": undefined,
+            "paddingHorizontal": undefined,
+            "paddingLeft": undefined,
+            "paddingRight": undefined,
+            "paddingTop": undefined,
+            "width": undefined,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#FFFFFF",
+              "borderColor": "#CCCCCC",
+              "borderRadius": 8,
+              "borderWidth": 2,
+              "padding": 15,
+            }
+          }
+        >
+          <View
+            pointerEvents="auto"
+            style={
+              Object {
+                "alignItems": undefined,
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "flex": undefined,
+                "flexDirection": "row",
+                "height": undefined,
+                "justifyContent": "center",
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginTop": undefined,
+                "padding": undefined,
+                "paddingBottom": undefined,
+                "paddingHorizontal": undefined,
+                "paddingLeft": undefined,
+                "paddingRight": undefined,
+                "paddingTop": undefined,
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="auto"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": undefined,
+                  "borderRadius": undefined,
+                  "flex": undefined,
+                  "flexDirection": undefined,
+                  "height": undefined,
+                  "justifyContent": "center",
+                  "margin": undefined,
+                  "marginBottom": undefined,
+                  "marginLeft": undefined,
+                  "marginRight": undefined,
+                  "marginTop": undefined,
+                  "padding": undefined,
+                  "paddingBottom": undefined,
+                  "paddingHorizontal": undefined,
+                  "paddingLeft": undefined,
+                  "paddingRight": undefined,
+                  "paddingTop": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#CCCCCC",
+                    "flexWrap": "wrap",
+                    "fontSize": 18,
+                  }
+                }
+              >
+                Done
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        pointerEvents="auto"
+        style={
+          Object {
+            "alignItems": undefined,
+            "backgroundColor": undefined,
+            "borderRadius": undefined,
+            "flex": 2,
+            "flexDirection": undefined,
+            "height": undefined,
+            "justifyContent": undefined,
+            "margin": undefined,
+            "marginBottom": undefined,
+            "marginLeft": undefined,
+            "marginRight": undefined,
+            "marginTop": undefined,
+            "padding": undefined,
+            "paddingBottom": undefined,
+            "paddingHorizontal": undefined,
+            "paddingLeft": undefined,
+            "paddingRight": undefined,
+            "paddingTop": undefined,
+            "width": undefined,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "alignItems": "center",
+              "backgroundColor": "#0078ff",
+              "borderRadius": 8,
+              "padding": 15,
+            }
+          }
+        >
+          <View
+            pointerEvents="auto"
+            style={
+              Object {
+                "alignItems": undefined,
+                "backgroundColor": undefined,
+                "borderRadius": undefined,
+                "flex": undefined,
+                "flexDirection": "row",
+                "height": undefined,
+                "justifyContent": "center",
+                "margin": undefined,
+                "marginBottom": undefined,
+                "marginLeft": undefined,
+                "marginRight": undefined,
+                "marginTop": undefined,
+                "padding": undefined,
+                "paddingBottom": undefined,
+                "paddingHorizontal": undefined,
+                "paddingLeft": undefined,
+                "paddingRight": undefined,
+                "paddingTop": undefined,
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="auto"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": undefined,
+                  "borderRadius": undefined,
+                  "flex": undefined,
+                  "flexDirection": undefined,
+                  "height": undefined,
+                  "justifyContent": "center",
+                  "margin": undefined,
+                  "marginBottom": undefined,
+                  "marginLeft": undefined,
+                  "marginRight": undefined,
+                  "marginTop": undefined,
+                  "padding": undefined,
+                  "paddingBottom": undefined,
+                  "paddingHorizontal": undefined,
+                  "paddingLeft": undefined,
+                  "paddingRight": undefined,
+                  "paddingTop": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "flexWrap": "wrap",
+                    "fontSize": 18,
+                  }
+                }
+              >
+                Save
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>,
+]
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10046,14 +10046,6 @@ react-native-typescript-transformer@^1.2.12:
     semver "^5.4.1"
     source-map "^0.5.6"
 
-react-native-uport-signer@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-uport-signer/-/react-native-uport-signer-1.6.1.tgz#452997433355efcb0de0d933cd19c15b08a3f3a8"
-  integrity sha512-OaArtXmUKVix9DeKHb5QJpvbK4p2UvyI9l9aG7U0096CXp46xYz+rpgLv+dC3j9E0Q0s8l+dOMOwagDtC8QLdg==
-  dependencies:
-    buffer "^5.2.1"
-    set-value "^2.0.1"
-
 react-native-vector-icons@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-6.6.0.tgz#66cf004918eb05d90778d64bd42077c1800d481b"


### PR DESCRIPTION
Pops up a modal after scanning message QR code and provides the user the option to save a credential. This could be used to verify a third party credential by adding revocation checks.